### PR TITLE
ci: auto-create GitHub Release from CHANGELOG on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,39 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Extract changelog notes for this tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#v}"
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
+            flag && /^## \[/ { exit }
+            flag { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            printf 'Release %s\n' "$TAG" > release-notes.md
+          fi
+          echo "----- release notes -----"
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --notes-file release-notes.md


### PR DESCRIPTION
## Summary

Makes GitHub Releases automatic. Today `publish.yml` only publishes to PyPI on a
`v*` tag — the GitHub Release has to be created by hand (as it was for v0.17.0).

This adds a `github-release` job that runs **after** the PyPI publish succeeds
(`needs: publish`) and:

- extracts the `## [<version>]` section from `CHANGELOG.md` matching the pushed
  tag (with the `v` prefix stripped), falling back to a minimal `Release <tag>`
  note if no section is found;
- creates the GitHub Release with `gh release create` using those notes.

## Safety

- The tag is passed through an `env:` var (`TAG`) and used quoted (`"$TAG"`),
  never interpolated directly into the shell — injection-safe.
- The job is scoped to `permissions: contents: write`; the PyPI job keeps its
  `id-token: write` / `contents: read`.
- Verified locally: `uvx zizmor .github/workflows/publish.yml` → no findings
  (CI gate runs at `min-severity: medium`), and the awk extraction was confirmed
  against the current CHANGELOG when creating the v0.17.0 release.

## Behaviour from here

Push a `vX.Y.Z` tag (after a `release: vX.Y.Z` commit that bumps the version and
lands the matching CHANGELOG section) → PyPI publish → GitHub Release, both
automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)