### PR TITLE
fix: sql execute timeout hands off to async lifecycle

### DIFF
--- a/src/maxcompute_semantic/_skill_data/query/SKILL.md
+++ b/src/maxcompute_semantic/_skill_data/query/SKILL.md
@@ -95,6 +95,11 @@ rebuilds use `mcs build`.
    ```bash
    mcs -f json sql execute '<SQL>'
    ```
+   `execute` waits `--timeout` seconds (default 30). If it exceeds that wait it
+   does **not** fail: the instance keeps running, so it returns
+   `data.sync_timed_out: true` with `data.instance_id` (+ `data.logview_url` /
+   `data.next_step`). Continue with the async path below using that
+   `instance_id` — do **not** resubmit the SQL.
    Async path:
    ```bash
    mcs -f json sql submit -y '<SQL>'

--- a/src/maxcompute_semantic/_skill_data/query/references/query.md
+++ b/src/maxcompute_semantic/_skill_data/query/references/query.md
@@ -222,6 +222,13 @@ verdict and query shape:
   prior timeout; any `verdict=confirm` query after user confirmation; or any
   query the user says can run in the background.
 
+Synchronous `execute` degrades into the async lifecycle on timeout: it waits
+`--timeout` seconds (default 30); if that elapses, the instance keeps running and
+`execute` returns `data.sync_timed_out: true` with `data.instance_id`,
+`data.logview_url`, and a `data.next_step` rather than failing. Pick up that
+`instance_id` with `sql wait` / `sql result`; never resubmit the same SQL after a
+sync timeout. Raise `--timeout` only when you want to keep waiting inline.
+
 ```bash
 mcs -f json sql submit -y '<SQL>'          # returns data.instance_id immediately
 mcs -f json sql status <instance_id>       # inspect data.lifecycle_state

--- a/src/maxcompute_semantic/build/phases.py
+++ b/src/maxcompute_semantic/build/phases.py
@@ -401,7 +401,9 @@ def phase_column_sampling(
         # (profile_budget_cny in BuildOptions) and run non-interactively, so
         # the per-call cost gate should not prompt — the blocked-ceiling
         # still fires and is caught as McsError below.
-        envelope = client.execute_sql(sql, schema=source.schema, hints=extra_hints, assume_yes=True)
+        envelope = client.execute_sql(
+            sql, schema=source.schema, hints=extra_hints, assume_yes=True, timeout=120,
+        )
         rows = envelope.data.get("rows", []) if envelope.data else []
     except McsError as exc:
         return PhaseResult(
@@ -576,7 +578,9 @@ def phase_column_profiling(
     try:
         # assume_yes=True: see sampling phase comment — build owns its
         # own cost budget; per-call cost gate should not prompt.
-        envelope = client.execute_sql(sql, schema=source.schema, hints=extra_hints, assume_yes=True)
+        envelope = client.execute_sql(
+            sql, schema=source.schema, hints=extra_hints, assume_yes=True, timeout=120,
+        )
     except McsError as exc:
         return PhaseResult(
             status="partial_failure",
@@ -675,7 +679,7 @@ def phase_mine_history(
     try:
         # assume_yes=True: see sampling phase comment — build owns its
         # own cost budget; per-call cost gate should not prompt.
-        envelope = client.execute_sql(sql, hints=hints, assume_yes=True)
+        envelope = client.execute_sql(sql, hints=hints, assume_yes=True, timeout=120)
         rows = envelope.data.get("rows", []) if envelope.data else []
     except McsError as exc:
         return PhaseResult(

--- a/src/maxcompute_semantic/commands/sql.py
+++ b/src/maxcompute_semantic/commands/sql.py
@@ -455,6 +455,7 @@ def execute_cmd(
         instance_id = str(e.context.get("instance_id") or "")
         if client is None or not instance_id:
             _emit_mcs_error(sql, client.profile if client is not None else None, e)
+            return  # _emit_mcs_error is NoReturn (sys.exit); this is for readers + linters
         try:
             status = client.get_instance_status(instance_id)
         except Exception:

--- a/src/maxcompute_semantic/commands/sql.py
+++ b/src/maxcompute_semantic/commands/sql.py
@@ -77,6 +77,7 @@ from maxcompute_semantic.auth.context import (
 )
 from maxcompute_semantic.commands._profile_command import profile_command
 from maxcompute_semantic.commands._schema_resolve import resolve_schema_for_tier
+from maxcompute_semantic.errors import TimeoutError as McsTimeoutError
 from maxcompute_semantic.mc_client.errors import McsError, WriteOpRejectedError
 from maxcompute_semantic.mc_client.sql_guard import (
     classify_sql as _classify_sql,
@@ -392,6 +393,17 @@ def sql_group() -> None:
         "before any cost-estimate round-trip."
     ),
 )
+@click.option(
+    "--timeout",
+    default=30,
+    type=click.IntRange(min=1),
+    help=(
+        "seconds to wait synchronously for the result (default: 30). On "
+        "timeout the query keeps running — the command returns its "
+        "instance_id + logview so you can continue with `mcs sql wait` / "
+        "`mcs sql result` instead of resubmitting."
+    ),
+)
 @click.argument("sql")
 @click.pass_context
 def execute_cmd(
@@ -403,6 +415,7 @@ def execute_cmd(
     result_offset: int,
     assume_yes: bool,
     allow_write: bool,
+    timeout: int,
     sql: str,
 ) -> None:
     """Execute a SQL statement against MaxCompute.
@@ -433,7 +446,36 @@ def execute_cmd(
             max_rows=max_rows,
             result_offset=result_offset,
             allow_write=allow_write,
+            timeout=timeout,
         )
+    except McsTimeoutError as e:
+        # The sync wait elapsed but the instance is still running. Hand it off
+        # to the async lifecycle so the caller continues with the instance_id
+        # (sql wait / sql result) instead of resubmitting the query.
+        instance_id = str(e.context.get("instance_id") or "")
+        if client is None or not instance_id:
+            _emit_mcs_error(sql, client.profile if client is not None else None, e)
+        try:
+            status = client.get_instance_status(instance_id)
+        except Exception:
+            status = {
+                "instance_id": instance_id,
+                "logview_url": e.context.get("logview_url", ""),
+                "lifecycle_state": "running",
+                "terminal": False,
+            }
+        # Include the routed project so the follow-up commands target the same
+        # project the query ran in (a multi-source profile routes execute to a
+        # source project that differs from the profile's default compute project).
+        proj = client.profile.compute_project
+        prof = f"--profile {profile} " if profile else ""
+        status["sync_timed_out"] = True
+        status["next_step"] = (
+            f"mcs sql wait {prof}--project {proj} {instance_id}; "
+            f"then mcs sql result {prof}--project {proj} {instance_id}"
+        )
+        emit_status(status)
+        return
     except McsError as e:
         _emit_mcs_error(sql, client.profile if client is not None else None, e)
 

--- a/src/maxcompute_semantic/mc_client/client.py
+++ b/src/maxcompute_semantic/mc_client/client.py
@@ -200,7 +200,7 @@ class MaxComputeClient:
         sql: str,
         *,
         hints: dict[str, str] | None = None,
-        timeout: int = 120,
+        timeout: int = 30,
         use_interactive: bool = False,
         schema: str | None = None,
         assume_yes: bool = False,
@@ -258,10 +258,28 @@ class MaxComputeClient:
             try:
                 instance.wait_for_success(interval=2, timeout=timeout)
             except TimeoutError as e:
+                # The instance keeps running server-side after the sync wait
+                # elapses. Surface its id + logview so callers (the `mcs sql
+                # execute` CLI) can hand off to the async lifecycle instead of
+                # discarding the already-submitted job.
+                instance_id = str(getattr(instance, "id", "") or "")
+                try:
+                    logview = instance.get_logview_address()
+                except Exception:
+                    logview = ""
                 raise McsTimeoutError(
-                    f"SQL execution exceeded {timeout}s",
-                    remediation="raise --timeout or split SQL into smaller queries",
+                    f"SQL execution exceeded the synchronous {timeout}s wait; "
+                    f"instance {instance_id} is still running",
+                    remediation=(
+                        "the query is still running — do not resubmit. Poll it "
+                        f"with `mcs sql wait --project {self._profile.compute_project}"
+                        f" {instance_id}`, then read rows with `mcs sql result "
+                        f"--project {self._profile.compute_project} {instance_id}`"
+                        + (f". Logview: {logview}" if logview else "")
+                    ),
                     sql=sql,
+                    instance_id=instance_id,
+                    logview_url=logview,
                 ) from e
         return self._build_success_envelope(
             instance,

--- a/tests/unit/commands/test_sql_cmd.py
+++ b/tests/unit/commands/test_sql_cmd.py
@@ -274,6 +274,97 @@ class TestSqlExecute:
         call_kwargs = mock_client.execute_sql.call_args
         assert call_kwargs.kwargs.get("result_offset") == 10000
 
+    def test_execute_timeout_flag_forwards_to_client(self, isolated_config: Path) -> None:
+        """``--timeout`` propagates to ``client.execute_sql``."""
+        mock_profile = _mock_profile()
+        mock_client = _mock_client(mock_profile)
+        mock_client.execute_sql.return_value = Envelope.success({"rows": [], "schema": []})
+
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            make_client_for_project=MagicMock(return_value=mock_client),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                [
+                    "execute",
+                    "--project",
+                    "my_proj",
+                    "--schema",
+                    "default",
+                    "--timeout",
+                    "5",
+                    "SELECT * FROM t",
+                ]
+            )
+
+        assert result.exit_code == 0
+        assert mock_client.execute_sql.call_args.kwargs.get("timeout") == 5
+
+    def test_execute_timeout_defaults_to_30s(self, isolated_config: Path) -> None:
+        """The synchronous wait defaults to 30s (was 120s) when --timeout is omitted."""
+        mock_profile = _mock_profile()
+        mock_client = _mock_client(mock_profile)
+        mock_client.execute_sql.return_value = Envelope.success({"rows": [], "schema": []})
+
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            make_client_for_project=MagicMock(return_value=mock_client),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                ["execute", "--project", "my_proj", "--schema", "default", "SELECT 1"]
+            )
+
+        assert result.exit_code == 0
+        assert mock_client.execute_sql.call_args.kwargs.get("timeout") == 30
+
+    def test_execute_sync_timeout_hands_off_to_async(self, isolated_config: Path) -> None:
+        """When the sync wait elapses, `execute` must not fail: it hands the
+        still-running instance off to the async lifecycle, emitting
+        ``sync_timed_out`` + ``instance_id`` + ``next_step`` so the agent
+        continues with ``sql wait`` / ``sql result`` instead of resubmitting."""
+        from maxcompute_semantic.errors import TimeoutError as McsTimeoutError
+
+        mock_profile = _mock_profile()
+        mock_client = _mock_client(mock_profile)
+        mock_client.execute_sql.side_effect = McsTimeoutError(
+            "SQL execution exceeded the synchronous 30s wait; the instance is still running",
+            remediation="poll with mcs sql wait",
+            sql="SELECT * FROM t",
+            instance_id="20260622083000_inst_001",
+            logview_url="http://logview/xyz",
+        )
+        mock_client.get_instance_status.return_value = {
+            "instance_id": "20260622083000_inst_001",
+            "lifecycle_state": "running",
+            "terminal": False,
+            "logview_url": "http://logview/xyz",
+        }
+
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            make_client_for_project=MagicMock(return_value=mock_client),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                ["execute", "--project", "my_proj", "--schema", "default", "SELECT * FROM t"]
+            )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["status"] == "success"
+        data = output["data"]
+        assert data["sync_timed_out"] is True
+        assert data["instance_id"] == "20260622083000_inst_001"
+        # next_step carries the real instance_id plus the routed --project so it
+        # is copy-pasteable even for a multi-source profile.
+        assert "20260622083000_inst_001" in data["next_step"]
+        assert "mcs sql wait" in data["next_step"]
+        assert "--project" in data["next_step"]
+        # It must reuse the running instance, not resubmit the query.
+        mock_client.get_instance_status.assert_called_once_with("20260622083000_inst_001")
+
     def test_execute_failure_outputs_error_envelope(self, isolated_config: Path) -> None:
         """On execution failure, output error envelope and exit 1."""
         mock_profile = _mock_profile()

--- a/tests/unit/commands/test_sql_cmd.py
+++ b/tests/unit/commands/test_sql_cmd.py
@@ -365,6 +365,69 @@ class TestSqlExecute:
         # It must reuse the running instance, not resubmit the query.
         mock_client.get_instance_status.assert_called_once_with("20260622083000_inst_001")
 
+    def test_execute_sync_timeout_fallback_when_status_probe_fails(
+        self, isolated_config: Path
+    ) -> None:
+        """When get_instance_status throws after a sync timeout, the CLI must
+        still emit a success envelope with the instance_id from the error
+        context (the defensive except branch in execute_cmd)."""
+        from maxcompute_semantic.errors import TimeoutError as McsTimeoutError
+
+        mock_profile = _mock_profile()
+        mock_client = _mock_client(mock_profile)
+        mock_client.execute_sql.side_effect = McsTimeoutError(
+            "exceeded 30s",
+            remediation="poll",
+            sql="SELECT 1",
+            instance_id="inst_status_fail",
+            logview_url="http://logview/abc",
+        )
+        mock_client.get_instance_status.side_effect = RuntimeError("network down")
+
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            make_client_for_project=MagicMock(return_value=mock_client),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                ["execute", "--project", "my_proj", "--schema", "default", "SELECT 1"]
+            )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        data = output["data"]
+        assert data["sync_timed_out"] is True
+        assert data["instance_id"] == "inst_status_fail"
+        assert data["logview_url"] == "http://logview/abc"
+
+    def test_execute_sync_timeout_no_instance_id_falls_through_to_error(
+        self, isolated_config: Path
+    ) -> None:
+        """When the timeout error carries no instance_id, the CLI must fall
+        through to the normal error path (line 457 coverage)."""
+        from maxcompute_semantic.errors import TimeoutError as McsTimeoutError
+
+        mock_profile = _mock_profile()
+        mock_client = _mock_client(mock_profile)
+        mock_client.execute_sql.side_effect = McsTimeoutError(
+            "exceeded 30s",
+            remediation="poll",
+            sql="SELECT 1",
+        )
+
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            make_client_for_project=MagicMock(return_value=mock_client),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                ["execute", "--project", "my_proj", "--schema", "default", "SELECT 1"]
+            )
+
+        assert result.exit_code == 1
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+
     def test_execute_failure_outputs_error_envelope(self, isolated_config: Path) -> None:
         """On execution failure, output error envelope and exit 1."""
         mock_profile = _mock_profile()

--- a/tests/unit/mc_client/test_execute_sql.py
+++ b/tests/unit/mc_client/test_execute_sql.py
@@ -233,6 +233,35 @@ def test_permission_denied_raises_classified() -> None:
         c.execute_sql("SELECT * FROM t")
 
 
+def test_execute_sql_timeout_carries_instance_id_for_async_handoff() -> None:
+    """A synchronous wait timeout must not lose the running job: the raised
+    error carries instance_id + logview so the CLI can hand off to the async
+    lifecycle (sql wait / sql result) instead of discarding the submission."""
+    c = _make_client()
+    c._tier = "3"
+
+    fake_inst = MagicMock()
+    fake_inst.id = "20260622083000_inst_001"
+    fake_inst.get_logview_address.return_value = "http://logview/xyz"
+    fake_inst.wait_for_success.side_effect = TimeoutError("deadline exceeded")
+
+    odps_mock = MagicMock()
+    odps_mock.run_sql.return_value = fake_inst
+    c._odps = odps_mock
+    c._creds_expiration = None
+
+    with pytest.raises(McsTimeoutError) as excinfo:
+        c.execute_sql("SELECT * FROM t", timeout=1)
+
+    ctx = excinfo.value.context
+    assert ctx["instance_id"] == "20260622083000_inst_001"
+    assert ctx["logview_url"] == "http://logview/xyz"
+    # The remediation must steer to the async lifecycle, not a nonexistent
+    # --timeout flag on `mcs sql execute`.
+    assert "sql wait" in excinfo.value.remediation
+    assert "do not resubmit" in excinfo.value.remediation.lower()
+
+
 def test_uses_interactive_when_requested() -> None:
     c = _make_client()
     c._tier = None

--- a/tests/unit/mc_client/test_execute_sql.py
+++ b/tests/unit/mc_client/test_execute_sql.py
@@ -262,6 +262,30 @@ def test_execute_sql_timeout_carries_instance_id_for_async_handoff() -> None:
     assert "do not resubmit" in excinfo.value.remediation.lower()
 
 
+def test_execute_sql_timeout_survives_logview_failure() -> None:
+    """If get_logview_address() throws, the timeout error still carries the
+    instance_id with an empty logview (the defensive except branch)."""
+    c = _make_client()
+    c._tier = "3"
+
+    fake_inst = MagicMock()
+    fake_inst.id = "inst_logview_fail"
+    fake_inst.get_logview_address.side_effect = RuntimeError("logview unavailable")
+    fake_inst.wait_for_success.side_effect = TimeoutError("deadline exceeded")
+
+    odps_mock = MagicMock()
+    odps_mock.run_sql.return_value = fake_inst
+    c._odps = odps_mock
+    c._creds_expiration = None
+
+    with pytest.raises(McsTimeoutError) as excinfo:
+        c.execute_sql("SELECT * FROM t", timeout=1)
+
+    ctx = excinfo.value.context
+    assert ctx["instance_id"] == "inst_logview_fail"
+    assert ctx["logview_url"] == ""
+
+
 def test_uses_interactive_when_requested() -> None:
     c = _make_client()
     c._tier = None


### PR DESCRIPTION
## Summary

- `mcs sql execute` no longer fails on sync timeout. The instance keeps
  running and the command returns `sync_timed_out: true` with the real
  `instance_id`, `logview_url`, and a copy-pasteable `next_step` (including
  `--profile`/`--project`) so the caller continues with `mcs sql wait` /
  `mcs sql result` instead of resubmitting.
- New `--timeout` flag (default **30s**, down from the old hard-coded 120s).
- The timeout error message now carries real values — no more placeholder
  `<instance_id>` or reference to a nonexistent `--timeout` flag.

## Tested

- 1555 unit tests pass, ruff clean, mypy clean.
- Live end-to-end against MaxCompute (profile `test2`): `--timeout 1` on a
  heavy self-join → `sync_timed_out: true` with real instance_id → copy-paste
  `next_step` → `wait` (success) → `result` (rows returned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)