### PR TITLE
pyproject classifiers + report-issue Aone project id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,13 @@ description = "MaxCompute semantic-layer-aware CLI: multi-profile auth + pyodps-
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: Apache Software License",
+]
 dependencies = [
     "click>=8.1",
     "filelock>=3.13",

--- a/src/maxcompute_semantic/_skill_data/report-issue/SKILL.md
+++ b/src/maxcompute_semantic/_skill_data/report-issue/SKILL.md
@@ -112,10 +112,10 @@ GitHub, and manual hand-off:
 ## Internal Aone flow
 
 The workitem is created in **an Aone project the user has write access to**,
-with `--related-space` pointing at the upstream project **2155299**
+with `--related-space` pointing at the upstream project **871418**
 ([Agent special project]) — the maintainer sees it in their personal
 "My workitems" view. This lets internal teams report issues without needing
-access to 2155299.
+access to 871418.
 
 Use category `bug` for defects, `req` for feature requests, `task` for
 miscellaneous tasks.
@@ -174,7 +174,7 @@ miscellaneous tasks.
    a1 project workitem create \
      --project <target_project> \
      --category {bug|req|task} \
-     --related-space 2155299 \
+     --related-space 871418 \
      --assignee 292165 \
      --title "[maxcompute-semantic] {title}" \
      --body-file /tmp/mcs-report-issue-<timestamp>.md \
@@ -188,9 +188,9 @@ miscellaneous tasks.
 
 ### Notes
 
-- **`--related-space 2155299`** is this skill's identity. It does **not** require
+- **`--related-space 871418`** is this skill's identity. It does **not** require
   access to the target project, so the link lands even if the user can't read
-  2155299. The target ID must reference a real Aone project (invalid IDs are
+  871418. The target ID must reference a real Aone project (invalid IDs are
   silently discarded).
 - **Default `--assignee 292165`** (`jiexian.hc`). Override when the user names
   someone else. Employee IDs avoid nickname ambiguity.


### PR DESCRIPTION
## Summary

Two small fixes batched together:

1. **Add Python classifiers** (`Programming Language :: Python :: 3.10/3.11/3.12`
   + license classifier) to `pyproject.toml`. The shields.io `pypi/pyversions`
   badge reads PyPI classifiers, not `requires-python`; without them the badge
   shows "missing". Takes effect on the next PyPI publish.

2. **report-issue Aone upstream project**: `2155299` → `871418` (5 references in
   the report-issue skill — related-space value, access notes, command example,
   and the Notes section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)