### PR TITLE
ci: tokenless Codecov upload (app installed on repo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,5 @@ jobs:
           disable_search: true
           flags: unittests
           name: maxcompute-semantic-py310
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           disable_telem: true


### PR DESCRIPTION
## Summary

Drop the `CODECOV_TOKEN` reference from the Codecov upload step. The token
belonged to a personal account and produced `Repository not found`. With the
Codecov GitHub App now installed on this repo, tokenless upload authenticates
via the app.

## Verification

This PR's CI will exercise the tokenless path — checking the "Upload coverage
to Codecov" step succeeds (no `Repository not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)