### PR TITLE
ci: grant id-token:write for Codecov tokenless (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # Codecov tokenless (OIDC) upload — required for protected branches
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Codecov tokenless upload authenticates via **OIDC**, which requires the
`id-token: write` workflow permission. Without it, uploads to protected
branches fail with:

> Token required because branch is protected

The Codecov GitHub App is already installed on this repo; this adds the
missing permission so tokenless works on `main` (and PRs).

## Verification

Merge triggers a `main` push CI run — check the "Upload coverage to Codecov"
step: should succeed (no "Repository not found" / "branch protected").

Refs: [Codecov: Error - Token required](https://docs.codecov.com/docs/error-token-required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)