### PR TITLE
ci: enable use_oidc for Codecov tokenless upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,5 +115,6 @@ jobs:
           disable_search: true
           flags: unittests
           name: maxcompute-semantic-py310
+          use_oidc: true
           fail_ci_if_error: false
           disable_telem: true


### PR DESCRIPTION
## Summary

Follow-up to #10. codecov-action does **not** use OIDC automatically — the
`id-token: write` permission alone is not enough. Both are required:

1. `permissions: id-token: write` (added in #10)
2. `use_oidc: true` on the action (this PR)

Without `use_oidc`, the action falls back to legacy tokenless, which protected
branches reject with "Token required because branch is protected".

Ref: [codecov-action README — OIDC upload](https://github.com/codecov/codecov-action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)