### PR TITLE
docs: add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/maxcompute-semantic)](https://pypi.org/project/maxcompute-semantic/)
 [![License](https://img.shields.io/github/license/aliyun/maxcompute-semantic)](LICENSE)
 [![CI](https://github.com/aliyun/maxcompute-semantic/actions/workflows/ci.yml/badge.svg)](https://github.com/aliyun/maxcompute-semantic/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/aliyun/maxcompute-semantic/graph/badge.svg)](https://codecov.io/gh/aliyun/maxcompute-semantic)
 [![English](https://img.shields.io/badge/lang-English-blue)](README.md)
 [![中文](https://img.shields.io/badge/lang-中文-red)](README.zh-cn.md)
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -4,6 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/maxcompute-semantic)](https://pypi.org/project/maxcompute-semantic/)
 [![License](https://img.shields.io/github/license/aliyun/maxcompute-semantic)](LICENSE)
 [![CI](https://github.com/aliyun/maxcompute-semantic/actions/workflows/ci.yml/badge.svg)](https://github.com/aliyun/maxcompute-semantic/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/aliyun/maxcompute-semantic/graph/badge.svg)](https://codecov.io/gh/aliyun/maxcompute-semantic)
 [![English](https://img.shields.io/badge/lang-English-blue)](README.md)
 [![中文](https://img.shields.io/badge/lang-中文-red)](README.zh-cn.md)
 


### PR DESCRIPTION
## Summary

Codecov tokenless (OIDC) upload now works (enabled in #10 + #11 —
`id-token: write` permission + `use_oidc: true`). The latest `main` push CI
uploaded coverage successfully (`Token length: 1870` OIDC token, no error).

This adds the Codecov badge to both READMEs:

```markdown
[![codecov](https://codecov.io/gh/aliyun/maxcompute-semantic/graph/badge.svg)](https://codecov.io/gh/aliyun/maxcompute-semantic)
```

The badge reads `unknown` until Codecov finishes processing the upload +
its badge cache refreshes (a few minutes to an hour), then shows the
coverage percentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)