### PR TITLE
fix(site): restore version placeholder so deploy injects version

### DIFF
--- a/site/docs.html
+++ b/site/docs.html
@@ -543,7 +543,7 @@
       <span class="mark" aria-hidden="true"></span>
       <span>mcs</span>
       <!-- v0.16 replaced by .github/workflows/pages.yml at deploy time; do not hand-edit -->
-      <span class="ver">v0.16</span>
+      <span class="ver">v__MINOR__</span>
     </a>
     <nav class="nav-links">
       <a href="index.html">home</a>

--- a/site/index.html
+++ b/site/index.html
@@ -995,7 +995,7 @@
       <span class="mark" aria-hidden="true"></span>
       <span>mcs</span>
       <!-- v0.16 replaced by .github/workflows/pages.yml at deploy time; do not hand-edit -->
-      <span class="ver">v0.16</span>
+      <span class="ver">v__MINOR__</span>
     </a>
     <nav class="nav-links">
       <a href="index.html" class="active">home</a>

--- a/site/release-notes.html
+++ b/site/release-notes.html
@@ -436,7 +436,7 @@
       <span class="mark" aria-hidden="true"></span>
       <span>mcs</span>
       <!-- v0.16 replaced by .github/workflows/pages.yml at deploy time; do not hand-edit -->
-      <span class="ver">v0.16</span>
+      <span class="ver">v__MINOR__</span>
     </a>
     <nav class="nav-links">
       <a href="index.html">home</a>

--- a/site/zh-cn/docs.html
+++ b/site/zh-cn/docs.html
@@ -533,7 +533,7 @@
       <span class="mark" aria-hidden="true"></span>
       <span>mcs</span>
       <!-- v0.16 replaced by .github/workflows/pages.yml at deploy time; do not hand-edit -->
-      <span class="ver">v0.16</span>
+      <span class="ver">v__MINOR__</span>
     </a>
     <nav class="nav-links">
       <a href="index.html">home</a>

--- a/site/zh-cn/index.html
+++ b/site/zh-cn/index.html
@@ -986,7 +986,7 @@
       <span class="mark" aria-hidden="true"></span>
       <span>mcs</span>
       <!-- v0.16 replaced by .github/workflows/pages.yml at deploy time; do not hand-edit -->
-      <span class="ver">v0.16</span>
+      <span class="ver">v__MINOR__</span>
     </a>
     <nav class="nav-links">
       <a href="index.html" class="active">home</a>

--- a/site/zh-cn/release-notes.html
+++ b/site/zh-cn/release-notes.html
@@ -428,7 +428,7 @@
       <span class="mark" aria-hidden="true"></span>
       <span>mcs</span>
       <!-- v0.16 replaced by .github/workflows/pages.yml at deploy time; do not hand-edit -->
-      <span class="ver">v0.16</span>
+      <span class="ver">v__MINOR__</span>
     </a>
     <nav class="nav-links">
       <a href="index.html">home</a>


### PR DESCRIPTION
## Summary

The deployed site has been stuck showing `v0.16` across every release. Cause:
the six `<span class="ver">…</span>` version markers had been hand-edited to the
literal `v0.16`, so `pages.yml`'s deploy-time substitution
(`sed s/v__MINOR__/v${MINOR}/`) matched nothing.

This restores the `v__MINOR__` placeholder in all six spans. On the next `main`
push the deploy step injects the current minor (`v0.17`) — verified locally:
`v__MINOR__` → `v0.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)