### PR TITLE
ci: publish via pypi environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Route the PyPI publish job through the `pypi` GitHub Actions environment
(matching the PyPI-side Trusted Publisher environment-protected setup). This
restores a proper deployment record per release and lets the environment hold
required reviewers / branch protection for stronger publish isolation.

## Note

This only takes effect on the **next tag push**. If you configured required
reviewers on the `pypi` environment, the publish job will pause for approval
after a tag is pushed — approve it in the Actions run (or Environments view)
to proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)