### PR TITLE
feat(sql): extract SET key=val into hints (transparent SET;SELECT) + drop oss update channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,15 @@ jobs:
           )
           if [ -n "$missing" ]; then echo "Missing SPDX header in:"; echo "$missing"; exit 1; fi
 
-      - name: Type check
-        run: uv run mypy src/
-
       - name: Test
+        # xdist: parallelise across cores. --dist loadscope keeps each test
+        # module on one worker (safer for module-scoped state / file locks).
+        # -x is replaced with --maxfail=1 (xdist-compatible stop-on-first-fail).
+        # mypy moved to .github/workflows/lint.yml (mypy-blocking job).
         run: |
           if [ "${{ matrix.python-version }}" = "3.10" ]; then
-            uv run pytest tests/ -m 'not live' -x -q \
+            uv run pytest tests/ -m 'not live' \
+              -n auto --dist loadscope --maxfail=1 -q \
               --junitxml=junit-${{ matrix.python-version }}.xml \
               --cov=maxcompute_semantic \
               --cov-report=xml \
@@ -71,7 +73,8 @@ jobs:
               --cov-report=term-missing:skip-covered \
               --cov-fail-under=90
           else
-            uv run pytest tests/ -m 'not live' -x -q \
+            uv run pytest tests/ -m 'not live' \
+              -n auto --dist loadscope --maxfail=1 -q \
               --junitxml=junit-${{ matrix.python-version }}.xml
           fi
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint (ruff + ty)
+name: Lint (ruff + ty + mypy)
 
 on:
   push:
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   lint-diff:
-    name: ruff + ty diff
+    name: ruff + ty + mypy diff
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -38,11 +38,17 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install ruff + ty
         run: |
           uv tool install ruff
           uv tool install ty
+
+      - name: Install project deps (for mypy)
+        run: uv sync --extra dev
 
       - name: Determine base ref
         id: base
@@ -60,7 +66,7 @@ jobs:
             echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run ruff + ty on HEAD
+      - name: Run ruff + ty + mypy on HEAD
         run: |
           mkdir -p .lint-reports/head
           ruff check src/ tests/ \
@@ -69,8 +75,10 @@ jobs:
           ty check src/ tests/ \
             --output-format gitlab --exit-zero \
             > .lint-reports/head/ty.json || true
+          uv run mypy src/ --show-error-codes --no-pretty --no-error-summary \
+            > .lint-reports/head/mypy.txt || true
 
-      - name: Run ruff + ty on base (via git worktree)
+      - name: Run ruff + ty + mypy on base (via git worktree)
         env:
           BASE_SHA: ${{ steps.base.outputs.sha }}
         run: |
@@ -80,16 +88,20 @@ jobs:
             echo "Base SHA == HEAD SHA, skipping base scan."
             echo '[]' > .lint-reports/base/ruff.json
             echo '[]' > .lint-reports/base/ty.json
+            : > .lint-reports/base/mypy.txt
           else
             git worktree add --detach /tmp/lint-base "$BASE_SHA"
             (
               cd /tmp/lint-base
+              uv sync --extra dev
               ruff check src/ tests/ \
                 --output-format json --exit-zero \
                 > "$GITHUB_WORKSPACE/.lint-reports/base/ruff.json" || true
               ty check src/ tests/ \
                 --output-format gitlab --exit-zero \
                 > "$GITHUB_WORKSPACE/.lint-reports/base/ty.json" || true
+              uv run mypy src/ --show-error-codes --no-pretty --no-error-summary \
+                > "$GITHUB_WORKSPACE/.lint-reports/base/mypy.txt" || true
             )
             git worktree remove --force /tmp/lint-base
           fi
@@ -111,6 +123,8 @@ jobs:
             --head-ruff .lint-reports/head/ruff.json \
             --base-ty   .lint-reports/base/ty.json \
             --head-ty   .lint-reports/head/ty.json \
+            --base-mypy .lint-reports/base/mypy.txt \
+            --head-mypy .lint-reports/head/mypy.txt \
             --base-dir  /tmp/lint-base \
             --base-ref  "$BASE_REF" \
             --head-ref  "$HEAD_REF" \
@@ -150,6 +164,15 @@ jobs:
               });
             }
 
+      - name: Upload lint reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lint-reports
+          path: .lint-reports/
+          if-no-files-found: ignore
+          retention-days: 14
+
   ruff-blocking:
     name: ruff enforcement (blocking)
     runs-on: ubuntu-latest
@@ -168,3 +191,27 @@ jobs:
 
       - name: ruff check
         run: ruff check src/ tests/
+
+  mypy-blocking:
+    name: mypy enforcement (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: mypy
+        # Relocated from ci.yml's test matrix (ran 3x, once per Python).
+        # mypy results are Python-version-independent; one run suffices.
+        run: uv run mypy src/

--- a/docs/superpowers/plans/2026-06-23-set-statement-extraction.md
+++ b/docs/superpowers/plans/2026-06-23-set-statement-extraction.md
@@ -1,0 +1,718 @@
+# SET Statement Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `SET key=val; <query>` scripts run transparently through `mcs sql` — SET statements are extracted into pyodps hints before the write guard and cost gate, so `SET;SELECT` classifies as the remaining statement (read, no `--allow-write`) and no longer hits `CostBlocked` via `execute_sql_cost`.
+
+**Architecture:** Add a pure helper `split_set_hints(sql) -> (stripped_sql, hints)` that uses the MaxCompute sqlglot tokenizer to split the SQL into verbatim statement segments at top-level semicolons, parses each segment, and converts assignment `SET key=val` segments into a hints dict while keeping all other segments (SELECT/DDL, and `SET LABEL` which parses as a `Command`) verbatim. Each of the 5 SQL verbs calls it first, then passes `stripped_sql` to the guard/routing/client and `set_hints` into the client's existing `hints=` kwarg. `classify_sql` is **unchanged** (non-extractable SETs like `SET LABEL` stay gated). The client layer already accepts and threads `hints` end-to-end, so no client changes are needed.
+
+**Tech Stack:** Python 3.10+, sqlglot (MaxCompute dialect registered as `maxcompute_semantic.dialect`), pytest, click (CLI).
+
+**Spec:** [docs/superpowers/specs/2026-06-23-set-statement-extraction-design.md](../specs/2026-06-23-set-statement-extraction-design.md)
+
+---
+
+## File Structure
+
+- **Create** `src/maxcompute_semantic/mc_client/sql_preprocess.py` — pure `split_set_hints(sql) -> (stripped_sql, hints)`. No I/O, no mcs imports beyond the dialect.
+- **Create** `tests/unit/mc_client/test_sql_preprocess.py` — unit tests for `split_set_hints`.
+- **Modify** `src/maxcompute_semantic/commands/sql.py` — add `_split_or_emit` helper (extraction + standalone-SET rejection); wire `submit_cmd`, `execute_cmd`, `cost_cmd`, `explain_cmd`, `review_cmd` to extract first and pass `stripped_sql` + `set_hints`.
+- **Modify** `tests/unit/commands/test_sql_cmd.py` — add verb-level integration tests; annotate the existing `test_set_is_write` (it stays — `classify_sql` is unchanged).
+
+**Unchanged (intentional):** `src/maxcompute_semantic/mc_client/sql_guard.py` (`classify_sql` and `_WRITE_SESSION_EXPR_TYPES` still treat `Set` as write — this is the belt ensuring non-extractable SETs stay gated), `src/maxcompute_semantic/mc_client/client.py` (all four execution methods already accept `hints=`), `src/maxcompute_semantic/mc_client/hints.py`, `src/maxcompute_semantic/mc_client/cost_gate.py`.
+
+---
+
+## Task 1: `split_set_hints` pure helper + unit tests
+
+**Files:**
+- Create: `tests/unit/mc_client/test_sql_preprocess.py`
+- Create: `src/maxcompute_semantic/mc_client/sql_preprocess.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/mc_client/test_sql_preprocess.py`:
+
+```python
+# Copyright (c) 2024-2026, Alibaba Cloud and its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for mc_client.sql_preprocess.split_set_hints."""
+
+from __future__ import annotations
+
+from maxcompute_semantic.mc_client.sql_preprocess import split_set_hints
+
+
+class TestSplitSetHints:
+    def test_extracts_set_and_preserves_select_verbatim(self) -> None:
+        sql = "SET odps.sql.mapper.split.size = 4096; SELECT a, b FROM t WHERE ds='20240101'"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT a, b FROM t WHERE ds='20240101'"
+        assert hints == {"odps.sql.mapper.split.size": "4096"}
+
+    def test_standalone_set_yields_empty_sql(self) -> None:
+        stripped, hints = split_set_hints("SET odps.sql.mapper.split.size=4096")
+        assert stripped == ""
+        assert hints == {"odps.sql.mapper.split.size": "4096"}
+
+    def test_multiple_sets_all_extracted(self) -> None:
+        sql = "SET odps.sql.allow.fullscan = true; SET odps.sql.reducer.memory = 4096; SELECT x FROM t"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT x FROM t"
+        assert hints == {"odps.sql.allow.fullscan": "TRUE", "odps.sql.reducer.memory": "4096"}
+
+    def test_semicolon_inside_string_literal_is_not_a_separator(self) -> None:
+        sql = "SET a=1; SELECT x FROM t WHERE s='a;b;c'"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT x FROM t WHERE s='a;b;c'"
+        assert hints == {"a": "1"}
+
+    def test_set_label_is_not_extracted_stays_verbatim(self) -> None:
+        sql = "SET LABEL tbl TO user; SELECT 1"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SET LABEL tbl TO user; SELECT 1"
+        assert hints == {}
+
+    def test_no_set_returns_unchanged(self) -> None:
+        stripped, hints = split_set_hints("SELECT 1 FROM dual")
+        assert stripped == "SELECT 1 FROM dual"
+        assert hints == {}
+
+    def test_non_select_preserved_verbatim_no_function_rewrite(self) -> None:
+        # TO_CHAR must NOT be rewritten to CAST — regeneration is lossy.
+        sql = "set odps.sql.type.system.odps2 = true; SELECT TO_CHAR(d, 'yyyyMMdd') FROM t"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT TO_CHAR(d, 'yyyyMMdd') FROM t"
+        assert hints == {"odps.sql.type.system.odps2": "TRUE"}
+
+    def test_trailing_semicolon_handled(self) -> None:
+        stripped, hints = split_set_hints("SET a=1; SELECT 1;")
+        assert stripped == "SELECT 1"
+        assert hints == {"a": "1"}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/mc_client/test_sql_preprocess.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'maxcompute_semantic.mc_client.sql_preprocess'`
+
+- [ ] **Step 3: Implement `split_set_hints`**
+
+Create `src/maxcompute_semantic/mc_client/sql_preprocess.py`:
+
+```python
+# Copyright (c) 2024-2026, Alibaba Cloud and its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract ``SET key=val`` statements into pyodps hints.
+
+Called by the ``mcs sql`` verbs before the write guard and cost gate, so
+``SET k=v; SELECT ...`` scripts run transparently (classified as the
+remaining statement) instead of being rejected as a write or blocked by
+the cost gate's ``execute_sql_cost`` (which, unlike ``run_sql``, does not
+strip SET to hints).
+"""
+
+from __future__ import annotations
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.tokens import TokenType
+
+from maxcompute_semantic.dialect import MaxCompute, parse_mc
+
+
+def split_set_hints(sql: str) -> tuple[str, dict[str, str]]:
+    """Extract ``SET key=val`` statements into hints.
+
+    Returns ``(sql_without_sets, hints)``. Uses the MaxCompute sqlglot
+    tokenizer to split the SQL into verbatim statement segments at
+    top-level semicolons (string- and comment-aware, so ``;`` inside a
+    literal or ``--`` comment is not a separator). Each segment is parsed
+    with ``parse_mc``; segments that parse to an assignment ``Set`` whose
+    every ``SetItem`` is an ``EQ`` (not ``UNSET``/tag, not a bare flag)
+    become hints and are dropped; all other segments (SELECT/DDL, and
+    ``SET LABEL`` which parses as a ``Command``) are kept verbatim and
+    rejoined.
+
+    Non-SET SQL is preserved verbatim (no AST regeneration): the MaxCompute
+    sqlglot generator rewrites functions (verified lossy: ``TO_CHAR(d,
+    fmt)`` -> ``CAST(d AS STRING)`` losing the format string, ``SUBSTRING``
+    -> ``SUBSTR``), which would change the user's SQL semantics. key/val
+    are read from the ``Set`` AST (``SetItem.this.this`` is the key,
+    ``.expression`` the value); boolean values normalize to
+    ``TRUE``/``FALSE`` (MaxCompute is case-insensitive on these) while
+    other literal forms round-trip.
+    """
+    hints: dict[str, str] = []
+    kept: list[str] = []
+    toks = MaxCompute.Tokenizer().tokenize(sql)
+    semi_ends = [t.end for t in toks if t.token_type is TokenType.SEMICOLON]
+    bounds = [-1, *semi_ends, len(sql)]
+    for i in range(len(bounds) - 1):
+        segment = sql[bounds[i] + 1 : bounds[i + 1]].strip()
+        if not segment:
+            continue
+        try:
+            stmts = parse_mc(segment, error_level=sqlglot.ErrorLevel.IGNORE)
+        except Exception:
+            stmts = []
+        stmt = stmts[0] if stmts else None
+        if (
+            isinstance(stmt, exp.Set)
+            and not stmt.args.get("unset")
+            and not stmt.args.get("tag")
+        ):
+            items = stmt.args.get("expressions") or []
+            eqs = [it for it in items if isinstance(it.this, exp.EQ)]
+            if eqs and len(eqs) == len(items):
+                for it in eqs:
+                    eq = it.this
+                    hints.append((eq.this.sql(dialect="maxcompute"), eq.expression.sql(dialect="maxcompute")))
+                continue
+        kept.append(segment)
+    return "; ".join(kept), dict(hints)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/mc_client/test_sql_preprocess.py -v`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/maxcompute_semantic/mc_client/sql_preprocess.py tests/unit/mc_client/test_sql_preprocess.py
+git commit -m "feat(mc_client): add split_set_hints to extract SET key=val into hints
+
+Uses the MaxCompute sqlglot tokenizer to split SQL into verbatim
+statement segments, then converts assignment SET statements into a
+hints dict while keeping all other segments (incl. SET LABEL) verbatim.
+Non-SET SQL is never regenerated (the generator rewrites functions
+lossily). Pure helper; not yet wired into the verbs."
+```
+
+---
+
+## Task 2: Wire `execute_cmd` + `submit_cmd` via `_split_or_emit`
+
+**Files:**
+- Modify: `src/maxcompute_semantic/commands/sql.py` (import near line 72; add `_split_or_emit` near `_guard_sql_execution` at line 286; modify `execute_cmd` body at line 437; modify `submit_cmd` body at line 526-531)
+- Modify: `tests/unit/commands/test_sql_cmd.py` (add tests in `TestSqlExecuteWriteGuard`)
+
+- [ ] **Step 1: Add the import**
+
+In `src/maxcompute_semantic/commands/sql.py`, add to the `mc_client` imports block (after the `sql_guard` imports around line 87):
+
+```python
+from maxcompute_semantic.mc_client.sql_preprocess import split_set_hints
+```
+
+- [ ] **Step 2: Add the `_split_or_emit` helper**
+
+Add this function immediately after `_guard_sql_execution` (after line 323, before `_client_and_schema_for_sql`):
+
+```python
+def _split_or_emit(sql: str) -> tuple[str, dict[str, str]]:
+    """Extract SET→hints; emit+exit if the SQL is only SETs (no query).
+
+    Shared by every ``mcs sql`` verb so the write guard, project routing,
+    cost gate, and pyodps submission all see the SET-free SQL and the
+    extracted hints. A standalone ``SET k=v`` (no query) is rejected with
+    ``WriteOpRejectedError`` because there is nothing to execute.
+    """
+    stripped_sql, set_hints = split_set_hints(sql)
+    if not stripped_sql.strip():
+        _emit_mcs_error(
+            sql,
+            None,
+            WriteOpRejectedError(
+                "SQL contained only SET statements with no query; nothing to execute",
+                remediation=(
+                    "add a SELECT/INSERT/... statement after the SET, or remove "
+                    "the SET if you only meant to set a session property"
+                ),
+                sql=sql,
+            ),
+        )
+    return stripped_sql, set_hints
+```
+
+- [ ] **Step 3: Wire `submit_cmd`**
+
+In `submit_cmd` (around line 525-536), replace:
+
+```python
+    """Submit SQL asynchronously and return the MaxCompute instance ID."""
+    _guard_sql_execution(sql, profile, allow_write=allow_write)
+
+    client = None
+    try:
+        client, schema = _client_and_schema_for_sql(project, profile, schema, sql)
+        instance_id = client.run_sql_async(
+            sql,
+            schema=schema,
+            assume_yes=assume_yes,
+            allow_write=allow_write,
+        )
+```
+
+with:
+
+```python
+    """Submit SQL asynchronously and return the MaxCompute instance ID."""
+    stripped_sql, set_hints = _split_or_emit(sql)
+    _guard_sql_execution(stripped_sql, profile, allow_write=allow_write)
+
+    client = None
+    try:
+        client, schema = _client_and_schema_for_sql(project, profile, schema, stripped_sql)
+        instance_id = client.run_sql_async(
+            stripped_sql,
+            schema=schema,
+            hints=set_hints or None,
+            assume_yes=assume_yes,
+            allow_write=allow_write,
+        )
+```
+
+- [ ] **Step 4: Wire `execute_cmd`**
+
+In `execute_cmd` (around line 437-450), replace:
+
+```python
+    _guard_sql_execution(sql, profile, allow_write=allow_write)
+
+    client = None
+    try:
+        client, schema = _client_and_schema_for_sql(project, profile, schema, sql)
+        envelope = client.execute_sql(
+            sql,
+            schema=schema,
+            assume_yes=assume_yes,
+            max_rows=max_rows,
+            result_offset=result_offset,
+            allow_write=allow_write,
+            timeout=timeout,
+        )
+```
+
+with:
+
+```python
+    stripped_sql, set_hints = _split_or_emit(sql)
+    _guard_sql_execution(stripped_sql, profile, allow_write=allow_write)
+
+    client = None
+    try:
+        client, schema = _client_and_schema_for_sql(project, profile, schema, stripped_sql)
+        envelope = client.execute_sql(
+            stripped_sql,
+            schema=schema,
+            hints=set_hints or None,
+            assume_yes=assume_yes,
+            max_rows=max_rows,
+            result_offset=result_offset,
+            allow_write=allow_write,
+            timeout=timeout,
+        )
+```
+
+- [ ] **Step 5: Write the failing integration tests**
+
+In `tests/unit/commands/test_sql_cmd.py`, add these methods to the `TestSqlExecuteWriteGuard` class (after `test_show_tables_default_succeeds`):
+
+```python
+    def test_set_then_select_runs_without_allow_write(self, isolated_config: Path) -> None:
+        # SET key=val is extracted to a hint; the remaining SELECT is a read,
+        # so --allow-write is NOT required.
+        result, mock_client = self._run(
+            ["execute", "--project", "p", "--schema", "default",
+             "SET odps.sql.mapper.split.size = 4096; SELECT 1"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_client.execute_sql.called
+        call = mock_client.execute_sql.call_args
+        assert call.args[0] == "SELECT 1"
+        assert call.kwargs["hints"] == {"odps.sql.mapper.split.size": "4096"}
+
+    def test_set_label_still_requires_allow_write(self, isolated_config: Path) -> None:
+        # SET LABEL is not key=val -> not extracted -> stays -> rejected.
+        result, mock_client = self._run(
+            ["execute", "--project", "p", "--schema", "default",
+             "SET LABEL tbl TO user; SELECT 1"]
+        )
+        assert result.exit_code == 2
+        assert not mock_client.execute_sql.called
+
+    def test_standalone_set_is_rejected(self, isolated_config: Path) -> None:
+        result, mock_client = self._run(
+            ["execute", "--project", "p", "--schema", "default",
+             "SET odps.sql.mapper.split.size = 4096"]
+        )
+        assert result.exit_code == 2
+        assert not mock_client.execute_sql.called
+        assert "no query" in result.output
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/commands/test_sql_cmd.py::TestSqlExecuteWriteGuard -v`
+Expected: PASS (including the 3 new tests; existing `test_select_default_succeeds`, `test_show_tables_default_succeeds` still pass).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/maxcompute_semantic/commands/sql.py tests/unit/commands/test_sql_cmd.py
+git commit -m "feat(sql): extract SET->hints in execute/submit verbs
+
+execute_cmd and submit_cmd now call _split_or_emit before the write
+guard, so SET key=val;SELECT runs as a read (no --allow-write) and
+the stripped SQL + SET hints reach execute_sql/run_sql_async (which
+already thread hints). Standalone SET (no query) is rejected. SET
+LABEL stays gated (not extracted)."
+```
+
+---
+
+## Task 3: Wire `cost_cmd` + `explain_cmd`
+
+**Files:**
+- Modify: `src/maxcompute_semantic/commands/sql.py` (`cost_cmd` body around line 696-702; `explain_cmd` body around line 737-742)
+- Modify: `tests/unit/commands/test_sql_cmd.py` (add tests; reuse the `_run`-style harness or the `profile_command` test pattern)
+
+- [ ] **Step 1: Wire `cost_cmd`**
+
+In `cost_cmd` (around line 696-702), replace:
+
+```python
+    client = None
+    try:
+        target_project = _route_project(pctx.project_override, pctx.profile.name, sql)
+        client = make_client_for_project(target_project, profile_name=pctx.profile.name)
+        tier = get_tier(client.profile, client.profile.compute_project, client=client)
+        schema = resolve_schema_for_tier(tier, pctx.schema_override, profile=client.profile)
+        result = client.cost_estimate(sql, schema=schema)
+    except McsError as e:
+        _emit_mcs_error(sql, client.profile if client is not None else pctx.profile, e)
+```
+
+with:
+
+```python
+    stripped_sql, set_hints = _split_or_emit(sql)
+    client = None
+    try:
+        target_project = _route_project(pctx.project_override, pctx.profile.name, stripped_sql)
+        client = make_client_for_project(target_project, profile_name=pctx.profile.name)
+        tier = get_tier(client.profile, client.profile.compute_project, client=client)
+        schema = resolve_schema_for_tier(tier, pctx.schema_override, profile=client.profile)
+        result = client.cost_estimate(stripped_sql, schema=schema, hints=set_hints or None)
+    except McsError as e:
+        _emit_mcs_error(stripped_sql, client.profile if client is not None else pctx.profile, e)
+```
+
+- [ ] **Step 2: Wire `explain_cmd`**
+
+In `explain_cmd` (around line 737-742), replace:
+
+```python
+    client = None
+    try:
+        target_project = _route_project(project, profile, sql)
+        client = make_client_for_project(target_project, profile_name=profile)
+        tier = get_tier(client.profile, client.profile.compute_project, client=client)
+        schema = resolve_schema_for_tier(tier, schema, profile=client.profile)
+        result = client.explain(sql, timeout=timeout, schema=schema)
+    except McsError as e:
+        _emit_mcs_error(sql, client.profile if client is not None else None, e)
+```
+
+with:
+
+```python
+    stripped_sql, set_hints = _split_or_emit(sql)
+    client = None
+    try:
+        target_project = _route_project(project, profile, stripped_sql)
+        client = make_client_for_project(target_project, profile_name=profile)
+        tier = get_tier(client.profile, client.profile.compute_project, client=client)
+        schema = resolve_schema_for_tier(tier, schema, profile=client.profile)
+        result = client.explain(stripped_sql, timeout=timeout, schema=schema, hints=set_hints or None)
+    except McsError as e:
+        _emit_mcs_error(stripped_sql, client.profile if client is not None else None, e)
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Add to `tests/unit/commands/test_sql_cmd.py`, alongside the existing `cost` tests (e.g. next to `test_3level_cost_applies_hints` around line 881). Mirror that test's harness exactly — it patches `make_client_for_project` + `get_tier` on `maxcompute_semantic.commands.sql` and invokes `cost` via `_invoke`:
+
+```python
+    def test_cost_strips_set_and_passes_hints(self, isolated_config: Path) -> None:
+        """SET key=val is extracted to a hint; cost_estimate gets the stripped
+        SELECT + the SET as hints (so execute_sql_cost never sees the SET)."""
+        mock_profile = _mock_profile()
+        mock_client = _mock_client(mock_profile)
+        mock_client.cost_estimate.return_value = {
+            "estimated_input_bytes": 0,
+            "estimated_cost_cny": 0.0,
+            "verdict": "ok",
+            "thresholds": {"confirm_cny": 10.0, "blocked_cny": 100.0},
+        }
+
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            make_client_for_project=MagicMock(return_value=mock_client),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                [
+                    "cost",
+                    "--project",
+                    "my_proj",
+                    "--schema",
+                    "my_schema",
+                    "SET odps.sql.mapper.split.size = 4096; SELECT * FROM t",
+                ]
+            )
+
+        assert result.exit_code == 0, result.output
+        call = mock_client.cost_estimate.call_args
+        assert call.args[0] == "SELECT * FROM t"
+        assert call.kwargs.get("hints") == {"odps.sql.mapper.split.size": "4096"}
+```
+
+`patch`, `MagicMock`, `_mock_profile`, `_mock_client`, `_invoke`, and the `isolated_config` fixture are all already used at the top of `test_sql_cmd.py` (see `test_3level_cost_applies_hints`), so no new imports are needed.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/commands/test_sql_cmd.py -k "cost_strips_set_and_passes_hints or 3level_cost" -v`
+Expected: PASS — `cost_estimate` is called with `SELECT * FROM t` + the SET hint. Existing cost tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/maxcompute_semantic/commands/sql.py tests/unit/commands/test_sql_cmd.py
+git commit -m "feat(sql): extract SET->hints in cost/explain verbs
+
+cost_cmd and explain_cmd now strip SET key=val into hints and pass the
+stripped SQL to cost_estimate / explain (both already accept hints=).
+Cost estimation on SET;SELECT no longer sends the SET to execute_sql_cost."
+```
+
+---
+
+## Task 4: Wire `review_cmd`
+
+**Files:**
+- Modify: `src/maxcompute_semantic/commands/sql.py` (`review_cmd` body around line 781-842)
+- Modify: `tests/unit/commands/test_sql_cmd.py` (add a review test)
+
+- [ ] **Step 1: Wire `review_cmd`**
+
+In `review_cmd` (around line 781-842), the SQL is used in `_route_project`, `_classify_sql`, `_emit_mcs_error`, and `build_review_envelope`. Extract first and use `stripped_sql` throughout. Replace the start of the body:
+
+```python
+    profile_obj: Profile | None = None
+    try:
+        profile_obj = resolve_profile_for_project(project, profile_name=profile)
+        # Sibling-parity routing: ...
+        target_project = _route_project(project, profile, sql)
+    except McsError as e:
+        _emit_mcs_error(sql, profile_obj, e)
+    assert profile_obj is not None
+```
+
+with:
+
+```python
+    stripped_sql, _set_hints = _split_or_emit(sql)
+    profile_obj: Profile | None = None
+    try:
+        profile_obj = resolve_profile_for_project(project, profile_name=profile)
+        # Sibling-parity routing: ...
+        target_project = _route_project(project, profile, stripped_sql)
+    except McsError as e:
+        _emit_mcs_error(stripped_sql, profile_obj, e)
+    assert profile_obj is not None
+```
+
+Then update the classify + refuse + envelope calls further down. Replace:
+
+```python
+    verdict = _classify_sql(sql)
+    if verdict != "read":
+        _emit_mcs_error(
+            sql,
+            profile_obj,
+            ReviewUnsupportedError(
+                f"mcs sql review is read-only; got SQL classified as {verdict!r}",
+```
+
+with:
+
+```python
+    verdict = _classify_sql(stripped_sql)
+    if verdict != "read":
+        _emit_mcs_error(
+            stripped_sql,
+            profile_obj,
+            ReviewUnsupportedError(
+                f"mcs sql review is read-only; got SQL classified as {verdict!r}",
+```
+
+And replace the `build_review_envelope(sql=sql, ...)` call:
+
+```python
+    data = build_review_envelope(
+        sql=sql,
+        profile=profile_obj,
+        project=target_project,
+        schema_name=schema,
+        tier=tier,
+    )
+```
+
+with:
+
+```python
+    data = build_review_envelope(
+        sql=stripped_sql,
+        profile=profile_obj,
+        project=target_project,
+        schema_name=schema,
+        tier=tier,
+    )
+```
+
+(`review` is read-only linting and does not execute, so the extracted `set_hints` are unused — discard via `_set_hints`.)
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `tests/unit/commands/sql_review/test_review_cmd.py`, alongside `test_review_refuses_write` (line 76). Mirror that test's harness — it patches `resolve_profile_for_project` + `get_tier` on `maxcompute_semantic.commands.sql`, invokes `review` via the local `_invoke`, and asserts on the JSON envelope:
+
+```python
+    def test_set_then_select_is_reviewable(self, isolated_config: Path, make_review_package) -> None:
+        """SET key=val is extracted; the remaining SELECT is a read -> review runs."""
+        profile, _ = make_review_package(
+            tables=[
+                {
+                    "source_key": "rev_proj__default",
+                    "name": "orders",
+                    "columns": [{"name": "id"}],
+                },
+            ],
+        )
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            resolve_profile_for_project=MagicMock(return_value=profile),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                [
+                    "review",
+                    "--project",
+                    "rev_proj",
+                    "--schema",
+                    "default",
+                    "SET odps.sql.mapper.split.size = 4096; SELECT id FROM orders",
+                ]
+            )
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert out["status"] == "success"
+        assert out["data"]["sql"] == "SELECT id FROM orders"
+```
+
+`json`, `Path`, `MagicMock`, `patch`, `_invoke`, and the `isolated_config` / `make_review_package` fixtures are all already used at the top of `test_review_cmd.py` (see `test_returns_success_envelope_with_review_data` and `test_review_refuses_write`), so no new imports are needed. The `out["data"]["sql"] == "SELECT id FROM orders"` assertion confirms the SET was stripped before review.
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/commands/sql_review/test_review_cmd.py -v`
+Expected: PASS — `SET;SELECT` is now reviewable; `test_review_refuses_write` (INSERT) still passes because INSERT is not a SET and is not extracted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/maxcompute_semantic/commands/sql.py tests/unit/commands/sql_review/test_review_cmd.py
+git commit -m "feat(sql): extract SET->hints in review verb
+
+review_cmd now reviews the SET-stripped SQL, so SET key=val;SELECT is
+reviewable instead of refused as a write. set_hints are unused (review
+is read-only linting). Non-extractable SETs (SET LABEL) still refused."
+```
+
+---
+
+## Task 5: Annotate `test_set_is_write` + full suite
+
+**Files:**
+- Modify: `tests/unit/commands/test_sql_cmd.py` (annotate `test_set_is_write` around line 2631-2634)
+
+- [ ] **Step 1: Annotate the classifier belt test**
+
+The existing `test_set_is_write` asserts `_classify_sql("SET odps.sql.allow.fullscan=true") == "write"`. This stays **unchanged** and correct: `classify_sql` is NOT modified by this change (non-extractable SETs like `SET LABEL` rely on it staying `write`). Add a clarifying comment so a future contributor does not "clean it up":
+
+Replace:
+
+```python
+    def test_set_is_write(self) -> None:
+        """SET mutates session state — requires --allow-write."""
+        from maxcompute_semantic.commands.sql import _classify_sql
+
+        assert _classify_sql("SET odps.sql.allow.fullscan=true") == "write"
+```
+
+with:
+
+```python
+    def test_set_is_write(self) -> None:
+        """SET mutates session state — requires --allow-write.
+
+        This stays 'write' on purpose: classify_sql is NOT modified by
+        the SET-extraction feature (see
+        docs/superpowers/specs/2026-06-23-set-statement-extraction-design.md).
+        Extraction happens in the verbs before classification, so
+        extractable SETs never reach classify_sql; non-extractable SETs
+        (SET LABEL, SETPROJECT) still do and must stay gated as write.
+        Do not remove this assertion.
+        """
+        from maxcompute_semantic.commands.sql import _classify_sql
+
+        assert _classify_sql("SET odps.sql.allow.fullscan=true") == "write"
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS — all existing tests green plus the new ones. If any test that previously asserted `SET;SELECT` was rejected as write now expects success, update it to the new behavior (the verb now extracts; `_classify_sql` itself is unchanged, so pure-classifier tests should not need changes).
+
+- [ ] **Step 3: Run the linters/type-checks the project uses**
+
+Run: `.venv/bin/python -m ruff check src/maxcompute_semantic/mc_client/sql_preprocess.py src/maxcompute_semantic/commands/sql.py tests/unit/mc_client/test_sql_preprocess.py tests/unit/commands/test_sql_cmd.py`
+And (if configured): `.venv/bin/python -m mypy src/maxcompute_semantic/mc_client/sql_preprocess.py`
+Expected: no errors. Fix any unused-import / naming findings inline.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/commands/test_sql_cmd.py
+git commit -m "test(sql): annotate test_set_is_write as the classify-unchanged belt
+
+classify_sql still classifies SET as 'write' by design (extraction
+happens in the verbs, not the classifier); non-extractable SETs rely on
+this. Comment added so the assertion is not removed."
+```
+
+---
+
+## Self-Review (completed during planning)
+
+**Spec coverage:** Every spec section maps to a task — extraction helper + mechanism (Task 1); `submit`/`execute` wiring + standalone-SET rejection + SET-LABEL gating (Task 2); `cost`/`explain` wiring (Task 3); `review` wiring (Task 4); `classify_sql` unchanged belt + full suite (Task 5). Hints merging/precedence is satisfied by reusing the client's existing `build_hints(user_hints=)` path (no new code). Cost-gate-no-longer-blocks is satisfied by the verb passing stripped SQL to `cost_estimate` (which calls `execute_sql_cost(stripped, hints)`).
+
+**Placeholder scan:** Task 3 Step 3 and Task 4 Step 2 note that the exact test harness should mirror existing `cost`/`review` test patterns in the file (the implementer greps for them) — the assertion contracts are fully specified (stripped SQL + SET hints passed). No "TBD"/"implement later".
+
+**Type consistency:** `split_set_hints` returns `tuple[str, dict[str, str]]` in Task 1 and is consumed as such in `_split_or_emit` (Task 2) and every verb. `_split_or_emit` returns `tuple[str, dict[str, str]]`. `set_hints or None` matches the client methods' `hints: dict[str, str] | None = None` signatures (verified for `execute_sql`, `run_sql_async`, `cost_estimate`, `explain`).
+
+**Known follow-up (out of scope, per spec):** a `--set`/`--hint` CLI flag, and a denylist for security-only SETs — not implemented here.

--- a/docs/superpowers/specs/2026-06-23-set-statement-extraction-design.md
+++ b/docs/superpowers/specs/2026-06-23-set-statement-extraction-design.md
@@ -1,0 +1,249 @@
+# SET Statement Extraction — Design
+
+Date: 2026-06-23
+Status: Approved (design), pending implementation plan
+Versions affected: all (0.16.2 → 0.17.3 behave identically; this is not a version-specific bug)
+
+## Background
+
+`mcs sql submit` / `mcs sql execute` fail when the SQL contains a `SET`
+statement, e.g. `SET odps.sql.mapper.split.size = 4096; SELECT ...`. Two
+independent causes were verified in code, tests, and empirical runs:
+
+### Cause 1 — write guard rejects SET
+
+`classify_sql` ([sql_guard.py:29](../../../src/maxcompute_semantic/mc_client/sql_guard.py))
+lists `sqlglot.exp.Set` under `_WRITE_SESSION_EXPR_TYPES`, so any SQL
+containing a SET is classified `"write"` and refused with
+`WriteOpRejectedError` (code `WRITE_OP_REJECTED`, exit 2) unless
+`--allow-write` is passed. This is by-design since v0.16.1 and test-asserted
+([test_sql_cmd.py:2634](../../../tests/unit/commands/test_sql_cmd.py)).
+
+### Cause 2 — cost gate blocks SET even with `--allow-write`
+
+`--allow-write` only clears the write guard. `enforce_cost_gate`
+([cost_gate.py:115](../../../src/maxcompute_semantic/mc_client/cost_gate.py))
+still runs and calls `odps.execute_sql_cost(sql)` with the **raw**
+`SET; SELECT` SQL. pyodps's `execute_sql_cost`
+([core.py:1466](../../../.venv/lib/python3.10/site-packages/odps/core.py))
+does **not** strip SET to hints — unlike `run_sql`, which does via
+`options.sql.parse_set_as_hints` (default `True`). The cost estimator
+receives the SET statement, typically cannot cost it, errors out, and
+because `SET; SELECT` is multi-statement `_is_low_risk_uncosted_read`
+([cost_gate.py:80](../../../src/maxcompute_semantic/mc_client/cost_gate.py))
+returns `False` → `CostBlockedError`. Both branches were verified by
+simulating `execute_sql_cost` success and failure locally:
+
+```text
+classify_sql("SET k=v; SELECT ...")            -> write
+_is_low_risk_uncosted_read("SET k=v; SELECT") -> False
+Case A (execute_sql_cost OK):   CLEARED  -> proceeds to run_sql
+Case B (execute_sql_cost ERR):  BLOCKED  -> CostBlockedError
+```
+
+### Key finding: SET has no write semantics
+
+pyodps treats `SET key=val` as **hints/settings**, not writes: `run_sql`'s
+`parse_set_as_hints` converts `SET key=val` into the `hints` dict using the
+regex `set\s+([a-z0-9.]+)\s*=\s*([^;]+)`. MaxCompute classifies SET as a
+session property (transient, instance-scoped), not DML/DDL. mcs's
+classification of SET as `"write"` was a conservative fail-closed proxy
+(code comment: "SET mutates session state, e.g. odps.sql.allow.fullscan"),
+not a reflection of true write semantics.
+
+### Version scope
+
+The behavior is **identical in 0.16.2 and 0.17.3**. Verified via full
+diffs between `v0.16.2` and `HEAD`: `client.py` only changed the
+synchronous-timeout handoff (`64497ba`); `sql_guard.py` / `cost_gate.py`
+only swapped `sqlglot.parse` → `parse_mc` with zero effect on SET
+classification (both parsers emit a `Set` node for `SET key=val`, confirmed
+empirically); `hints.py` unchanged; the MaxCompute dialect (added `0.17.0`)
+does not change SET+SELECT parsing. There is no 0.16.2-specific bug; the
+fix applies to all versions.
+
+## Goal
+
+Make `SET key=val; <query>` scripts work transparently: SET statements are
+extracted into pyodps hints, and the remaining query is classified and
+executed normally — no `--allow-write` needed for `SET; SELECT`.
+
+## Non-goals
+
+- Not adding a `--set` / `--hint` CLI flag. Extraction handles pre-baked
+  `SET; SELECT` scripts (what agents/users actually write); a flag is
+  unnecessary friction and does not help pre-baked scripts.
+- Not changing how non-hint SETs (`SET LABEL`, `SETPROJECT`, …) are
+  handled — they stay in the SQL and keep current classification.
+- Not removing or weakening the cost gate. It still runs and remains the
+  cost backstop.
+
+## Design
+
+### Decision: extract SET→hints, classify the remaining statement
+
+`SET key=val` statements are removed from the SQL text and collected into a
+hints dict. The remaining SQL is classified under the existing
+read/write/unparseable rules:
+
+- `SET k=v; SELECT ...` → `read` (no `--allow-write` needed)
+- `SET k=v; INSERT ...` → `write` (`--allow-write` required, for the INSERT)
+- `SET LABEL x TO y; SELECT ...` → `SET LABEL` not extracted (not `key=val`)
+  → stays → classified as before
+
+### What does NOT change
+
+`classify_sql` and `_WRITE_SESSION_EXPR_TYPES` (which still contains
+`sqlglot.exp.Set`) are **not modified**. The extraction layer runs before
+classification, so `classify_sql` only ever sees SET-free SQL for
+extractable scripts. Non-extractable SETs (`SET LABEL`, `SETPROJECT`) still
+reach `classify_sql` and are still classified `write`/`unparseable` —
+which is the desired behavior (those are real session/security ops that
+stay gated by `--allow-write`). Do not "clean up" the Set classification as
+part of this change; doing so would let `SET LABEL` slip through ungated.
+
+### Approach (chosen): extract once at each verb, thread stripped SQL + hints
+
+New pure helper in a new module
+`src/maxcompute_semantic/mc_client/sql_preprocess.py`:
+
+```python
+def split_set_hints(sql: str) -> tuple[str, dict[str, str]]:
+    """Extract `SET key=val` statements into hints.
+
+    Returns ``(sql_without_sets, hints)``. Uses the MaxCompute sqlglot
+    tokenizer to split the SQL into verbatim statement segments at
+    top-level semicolons (string- and comment-aware, so ``;`` inside
+    literals or ``--`` comments is not treated as a separator). Each
+    segment is parsed with ``parse_mc``; segments that parse to an
+    assignment ``Set`` (a ``SetItem`` with an ``EQ``, not ``UNSET``/tag)
+    become hints; all other segments (SELECT/DDL, and ``SET LABEL`` which
+    parses as a ``Command``) are kept verbatim and rejoined.
+
+    Non-SET SQL is preserved verbatim (no AST regeneration): the MaxCompute
+    sqlglot generator rewrites functions (verified: ``TO_CHAR(d, fmt)`` →
+    ``CAST(d AS STRING)`` losing the format string, ``SUBSTRING`` →
+    ``SUBSTR``, ``GROUP_CONCAT`` → ``WM_CONCAT``), which would change the
+    user's SQL semantics. key/val are read from the ``Set`` AST
+    (``SetItem.this.this`` is the key, ``.expression`` the value); boolean
+    values normalize to ``TRUE``/``FALSE`` (MaxCompute is case-insensitive
+    on these) while other literal forms round-trip.
+    """
+```
+
+**Extraction mechanism** (sqlglot-based, verbatim-preserving):
+
+1. Tokenize the SQL with the MaxCompute dialect tokenizer. Tokens carry
+   char offsets (`start`/`end`) and the tokenizer is string- and
+   comment-aware, so a `;` inside a string literal or `--` comment is not
+   emitted as a `SEMICOLON` token.
+2. Slice the original SQL at each top-level `SEMICOLON` token's position
+   into verbatim statement segments.
+3. Parse each segment with `parse_mc`. If it parses to an assignment `Set`
+   (`isinstance(stmt, exp.Set)` and not `unset`/`tag`), read its `SetItem`
+   key/val from the AST into `hints` and drop the segment. Otherwise keep
+   the verbatim segment (`SET LABEL` parses as a `Command`, so it stays).
+4. Rejoin the kept segments with a `;` separator.
+
+The non-SET SQL is never regenerated — only original substrings are
+recombined — so the function rewrites the MaxCompute generator would apply
+(verified lossy: `TO_CHAR` → `CAST`, `SUBSTRING` → `SUBSTR`,
+`GROUP_CONCAT` → `WM_CONCAT`) never touch the user's query.
+
+Each verb calls `split_set_hints` as its **first** step, before
+`_guard_sql_execution` / `_route_project` / client construction:
+
+```python
+# commands/sql.py — submit_cmd (and execute_cmd / cost_cmd / explain_cmd / review_cmd)
+def submit_cmd(..., sql):
+    stripped_sql, set_hints = split_set_hints(sql)
+    _guard_sql_execution(stripped_sql, profile, allow_write=allow_write)
+    client, schema = _client_and_schema_for_sql(project, profile, schema, stripped_sql)
+    instance_id = client.run_sql_async(
+        stripped_sql, schema=schema, hints=set_hints or None,
+        assume_yes=assume_yes, allow_write=allow_write,
+    )
+```
+
+`run_sql_async` / `execute_sql` / `cost_estimate` receive `hints` (now
+carrying extracted SETs) and the stripped SQL:
+
+- **write guard** sees stripped SQL (no SET) → classifies the actual
+  statement (`SET; SELECT` → `read`).
+- **cost gate** calls `execute_sql_cost(stripped_sql, hints=merged)` →
+  clean SELECT + SET-as-hints → estimates normally, no `CostBlocked`.
+- **`run_sql`** receives `stripped_sql` + `hints=merged` → pyodps finds no
+  SET (already stripped) and uses mcs's hints. mcs extracts once and passes
+  the same stripped SQL + hints to both `execute_sql_cost` and `run_sql`, so
+  the cost estimate and execution process identical SQL.
+
+### Hints merging / precedence
+
+Extracted `set_hints` enter `build_hints` via the `user_hints=` position
+([hints.py:23](../../../src/maxcompute_semantic/mc_client/hints.py)), which
+uses `setdefault`. Precedence is therefore:
+caller-supplied `hints` > extracted SETs > tier-derived
+(`odps.namespace.schema`). Explicit user hints win, matching pyodps's
+`code_hints.update(hints)` semantics.
+
+### Guardrail analysis: no denylist needed
+
+Only `SET key=val` (hint form) is extracted → becomes a read-enabling hint.
+Security-relevant SETs that do not match the hint regex (`SET LABEL …`,
+`SETPROJECT`) stay in the SQL and keep current write/unparseable
+classification (still gated by `--allow-write`). The guardrail is therefore
+naturally preserved for non-hint SETs without a maintained denylist.
+
+For cost-relevant hint SETs that **are** extracted (e.g.
+`odps.sql.allow.fullscan=true`): the cost gate still estimates the resulting
+query (with the SET applied as a hint) and blocks if it exceeds
+`blocked_cny`. So the cost gate remains the backstop; dropping the
+SET→write gate does not remove cost safety.
+
+The narrow residual gap — security-only, non-cost SETs (e.g. system-table
+access) that the cost gate cannot price — is out of scope for this change
+and can be addressed with a denylist later if it becomes a real concern.
+
+## Edge cases
+
+| Case | Behavior |
+| --- | --- |
+| `SET k=v; SELECT ...` | Extracted → `read`, runs without `--allow-write` |
+| `SET k=v; INSERT ...` | Extracted → `write`, `--allow-write` required (for the INSERT) |
+| `SET a=1; SET b=2; SELECT ...` | All SETs extracted → `read` |
+| Standalone `SET k=v` (no query) | `stripped_sql` empty → reject with `WriteOpRejectedError`-class: "SET with no query — nothing to execute", remediation "add a SELECT/INSERT after the SET" |
+| `SET LABEL x TO y; SELECT ...` | `SET LABEL` not extracted (not `key=val`) → stays → classified as before |
+| No SET in SQL | `split_set_hints` returns `(sql, {})` unchanged — zero behavior change |
+
+## Verb scope
+
+All five `mcs sql` verbs that take a SQL argument:
+`submit`, `execute`, `cost`, `explain`, `review`. `review` is read-only
+linting and calls `_classify_sql` directly; after extraction it classifies
+the stripped SELECT and can lint it (currently it refuses `SET; SELECT` as
+"write", which is also fixed by this change).
+
+## Test impact
+
+- **Update** [test_sql_cmd.py:2631-2634](../../../tests/unit/commands/test_sql_cmd.py):
+  `SET k=v; SELECT 1` now classifies `read`; pure standalone `SET k=v`
+  rejected. Replace the `SET == "write"` assertion.
+- **Add** `tests/unit/mc_client/test_sql_preprocess.py`:
+  - `split_set_hints` extracts `SET k=v`, preserves the SELECT verbatim,
+    handles multi-SET, leaves `SET LABEL` in the SQL, returns `(sql, {})`
+    when no SET.
+  - standalone `SET` → empty `stripped_sql` → rejection.
+- **Add** cost-gate test: `SET k=v; SELECT ...` with a mocked
+  `execute_sql_cost` — assert the stripped SQL is passed and `set_hints`
+  land in `hints`, verdict `ok`, no `CostBlocked`.
+- **Add** integration test in `TestSqlExecuteWriteGuard`
+  ([test_sql_cmd.py](../../../tests/unit/commands/test_sql_cmd.py)):
+  `mcs sql execute "SET k=v; SELECT 1"` succeeds without `--allow-write`;
+  `SET LABEL ...; SELECT 1` still requires `--allow-write`.
+
+## Out of scope / future
+
+- `--set` / `--hint` CLI flag — could layer on top later if users want to
+  set hints without embedding SET in SQL.
+- Denylist for security-only SETs (system-table access) if the cost-gate
+  backstop proves insufficient in practice.

--- a/scripts/lint_diff.py
+++ b/scripts/lint_diff.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -68,6 +69,36 @@ def _normalize_ty(entries: list[dict]) -> list[dict]:
                 "path": loc.get("path", ""),
                 "line": begin.get("line", 0),
                 "message": e.get("description", ""),
+            }
+        )
+    return out
+
+
+# mypy plain-text line:  src/pkg/foo.py:123: error: <msg>  [code]
+# (column optional; ``[code]`` present with --show-error-codes; notes ignored.)
+_MYPY_LINE = re.compile(
+    r"^(?P<path>[^:\s][^:]*):(?P<line>\d+)(?::\d+)?:\s*"
+    r"(?P<severity>error|warning):\s*(?P<message>.*?)"
+    r"(?:\s{2}\[(?P<rule>[^\]]+)\])?\s*$"
+)
+
+
+def _load_mypy_text(path: Path | None) -> list[dict]:
+    """Parse mypy plain-text output (``--show-error-codes --no-pretty``)."""
+    if path is None or not path.exists() or path.stat().st_size == 0:
+        return []
+    out: list[dict] = []
+    for line in path.read_text(errors="replace").splitlines():
+        m = _MYPY_LINE.match(line)
+        if not m:
+            continue
+        out.append(
+            {
+                "tool": "mypy",
+                "rule": m.group("rule") or m.group("severity"),
+                "path": m.group("path"),
+                "line": int(m.group("line")),
+                "message": m.group("message"),
             }
         )
     return out
@@ -168,6 +199,10 @@ def main() -> int:
     ap.add_argument("--head-ruff", type=Path, required=True)
     ap.add_argument("--base-ty", type=Path, required=True)
     ap.add_argument("--head-ty", type=Path, required=True)
+    ap.add_argument("--base-mypy", type=Path, default=None,
+                    help="mypy plain-text report on base (optional)")
+    ap.add_argument("--head-mypy", type=Path, default=None,
+                    help="mypy plain-text report on HEAD (optional)")
     ap.add_argument("--base-dir", type=Path, default=None,
                     help="Base worktree directory for ruff path normalization")
     ap.add_argument("--base-ref", default="base")
@@ -186,14 +221,22 @@ def main() -> int:
     head_ruff = _normalize_ruff(head_ruff_raw)
     base_ty = _normalize_ty(base_ty_raw)
     head_ty = _normalize_ty(head_ty_raw)
+    base_mypy = _load_mypy_text(args.base_mypy)
+    head_mypy = _load_mypy_text(args.head_mypy)
 
     base_ruff_avail = args.base_ruff.exists() and args.base_ruff.stat().st_size > 0
     base_ty_avail = args.base_ty.exists() and args.base_ty.stat().st_size > 0
+    base_mypy_avail = (
+        args.base_mypy is not None
+        and args.base_mypy.exists()
+        and args.base_mypy.stat().st_size > 0
+    )
 
     buf: list[str] = []
     buf.append(f"# \U0001f50e Lint report: `{args.head_ref}` vs `{args.base_ref}`\n")
     buf.append(_tool_report("ruff", base_ruff, head_ruff, base_ruff_avail))
     buf.append(_tool_report("ty (type checker)", base_ty, head_ty, base_ty_avail))
+    buf.append(_tool_report("mypy (type checker)", base_mypy, head_mypy, base_mypy_avail))
     buf.append(
         "_Diagnostics are surfaced as warnings — this check never fails the build._\n"
     )

--- a/src/maxcompute_semantic/_internal/update_check.py
+++ b/src/maxcompute_semantic/_internal/update_check.py
@@ -5,11 +5,9 @@
 
 The module's job is the *passive* version-awareness layer of mcs:
 
-- ``fetch_latest_metadata`` synchronously pulls
-  ``MCS_UPDATE_BASE_URL/latest.json`` (default
-  ``https://maxcompute-semantic.oss-cn-beijing.aliyuncs.com``) with a
-  short timeout. Returns ``None`` on any failure so callers don't need
-  exception handling.
+- ``fetch_latest_metadata`` synchronously pulls PyPI project metadata
+  (default ``https://pypi.org/pypi/maxcompute-semantic/json``) with a
+  short timeout.
 - ``read_cache`` / ``write_cache`` / ``should_check`` manage a
   per-user JSON cache at ``cache_dir()/update_check.json`` so the
   network probe is amortized across mcs invocations (default TTL 6 h).
@@ -30,9 +28,7 @@ The cache schema lives at module top so the producer (the daemon
 probe) and the consumer (``cli.py`` finally block, ``commands/doctor.py``)
 agree.
 
-For the publish-side companion (``latest.json`` schema, the OSS upload
-order, the disabled-versions CSV input), see the spec's
-"Release pipeline" section.
+PyPI is the only publisher for the update channel.
 """
 
 from __future__ import annotations
@@ -49,54 +45,41 @@ from typing import Any
 
 from maxcompute_semantic._internal.paths import cache_dir
 
-DEFAULT_BASE_URL = "https://maxcompute-semantic.oss-cn-beijing.aliyuncs.com"
+DEFAULT_BASE_URL = "https://pypi.org/pypi/maxcompute-semantic"
 """Hardcoded fallback. Override via ``MCS_UPDATE_BASE_URL`` env var.
 
-The forward-compat seam: when mcs moves to PyPI, the env var points
-``https://pypi.org`` and ``fetch_latest_metadata`` switches the
-envelope adapter to the PyPI JSON shape (``{"info": {"version": ...},
-"urls": [{"url": ...}]}``). The cache, banner, and install-mode
-detection don't change — they all consume the normalized
-``LatestMetadata``."""
+The default is a PyPI project URL without the trailing ``/json`` so the
+same helper can accept ``https://pypi.org`` or the full project path and
+normalize it via ``_metadata_url``. The cache, banner, and install-mode
+detection consume normalized ``LatestMetadata``."""
+
+_PYPI_HOST = "pypi.org"
+_PYPI_PROJECT_PATH = "/pypi/maxcompute-semantic"
 
 _ALLOWED_HOSTS: frozenset[str] = frozenset(
     {
-        "maxcompute-semantic.oss-cn-beijing.aliyuncs.com",
+        _PYPI_HOST,
     }
 )
 _SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
 
 _SCHEMA_VERSION = 1
-"""The only ``latest.json`` schema_version this client understands.
+"""Internal normalized metadata schema version used for cache wrappers."""
 
-The spec says: bump on incompatible changes. The consumer falls
-through to ``None`` if it sees a higher schema_version so an old
-client gracefully ignores a future publisher."""
+_PYPI_USER_AGENT = "mcs/{version} maxcompute-semantic/{version}"
+"""PyPI asks API clients to identify themselves via User-Agent."""
 
 
 class UpdateCheckError(Exception):
     """Base class for the two specific error types below."""
 
 
-class UnsupportedSchemaError(UpdateCheckError):
-    """``schema_version`` in the fetched JSON exceeds what this client
-    understands. The caller treats this as "no metadata available."""
-
-    def __init__(self, got: int, supported: int) -> None:
-        super().__init__(
-            f"latest.json schema_version={got} > supported={supported}; "
-            f"ignoring metadata (please upgrade mcs)"
-        )
-        self.got = got
-        self.supported = supported
-
-
 class MalformedMetadataError(UpdateCheckError):
     """A required field is missing or wrong-typed."""
 
     def __init__(self, message: str) -> None:
-        super().__init__(f"malformed latest.json: {message}")
+        super().__init__(f"malformed PyPI metadata: {message}")
 
 
 def _require_str(d: dict[str, Any], key: str) -> str:
@@ -108,31 +91,6 @@ def _require_str(d: dict[str, Any], key: str) -> str:
     if not isinstance(val, str):
         raise MalformedMetadataError(f"field '{key}' must be a string, got {type(val).__name__}")
     return val
-
-
-def _require_int(d: dict[str, Any], key: str) -> int:
-    if key not in d:
-        raise MalformedMetadataError(f"missing required field '{key}'")
-    val = d[key]
-    if not isinstance(val, int) or isinstance(val, bool):
-        raise MalformedMetadataError(f"field '{key}' must be an integer, got {type(val).__name__}")
-    return val
-
-
-def _require_str_list(d: dict[str, Any], key: str) -> tuple[str, ...]:
-    if key not in d:
-        raise MalformedMetadataError(f"missing required field '{key}'")
-    val = d[key]
-    if not isinstance(val, list):
-        raise MalformedMetadataError(f"field '{key}' must be a list, got {type(val).__name__}")
-    out: list[str] = []
-    for i, x in enumerate(val):
-        if not isinstance(x, str):
-            raise MalformedMetadataError(
-                f"field '{key}[{i}]' must be a string, got {type(x).__name__}"
-            )
-        out.append(x)
-    return tuple(out)
 
 
 def _optional_str(d: dict[str, Any], key: str, default: str = "") -> str:
@@ -149,13 +107,9 @@ def _require_sha256(d: dict[str, Any], key: str) -> str:
     return val.lower()
 
 
-def _truthy_env(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
 @dataclasses.dataclass(frozen=True)
 class LatestMetadata:
-    """Parsed ``latest.json`` body. Frozen so caches can't accidentally
+    """Parsed PyPI update metadata. Frozen so caches can't accidentally
     mutate shared instances."""
 
     schema_version: int
@@ -168,28 +122,57 @@ class LatestMetadata:
     sha256: str
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> LatestMetadata:
-        """Validating constructor. Raises ``UnsupportedSchemaError`` if
-        the publisher emitted a newer schema than we know, or
-        ``MalformedMetadataError`` if a required field is missing or
-        the wrong type. ``notice`` defaults to empty if absent."""
-        sv = _require_int(d, "schema_version")
-        if sv != _SCHEMA_VERSION:
-            # The spec carves out forward-compatibility: an old client
-            # that sees a newer schema must ignore the metadata
-            # entirely. We treat lower schema_versions the same way
-            # (the publisher is broken if it sends 0, but the client
-            # is the wrong place to fix that).
-            raise UnsupportedSchemaError(got=sv, supported=_SCHEMA_VERSION)
+    def from_pypi_dict(cls, d: dict[str, Any]) -> LatestMetadata:
+        """Normalize PyPI's project JSON shape into ``LatestMetadata``.
+
+        PyPI publishes the latest version under ``info.version`` and the
+        concrete artifacts under ``urls[]``. mcs is a universal wheel, so
+        the update channel chooses the non-yanked ``bdist_wheel`` whose
+        filename matches the published version, carries PyPI's SHA256
+        digest forward, and leaves the legacy hard-block fields empty.
+        """
+        info = d.get("info")
+        if not isinstance(info, dict):
+            raise MalformedMetadataError("missing PyPI info object")
+        latest_version = info.get("version")
+        if not isinstance(latest_version, str) or not latest_version:
+            raise MalformedMetadataError("PyPI info.version must be a non-empty string")
+
+        urls = d.get("urls")
+        if not isinstance(urls, list):
+            raise MalformedMetadataError("PyPI urls must be a list")
+
+        expected_filename = f"maxcompute_semantic-{latest_version}-py3-none-any.whl"
+        wheel: dict[str, Any] | None = None
+        for item in urls:
+            if not isinstance(item, dict):
+                raise MalformedMetadataError("PyPI urls entries must be objects")
+            if item.get("packagetype") != "bdist_wheel":
+                continue
+            if item.get("yanked") is True:
+                continue
+            if item.get("filename") != expected_filename:
+                continue
+            wheel = item
+            break
+        if wheel is None:
+            raise MalformedMetadataError(
+                f"PyPI payload has no non-yanked wheel named {expected_filename!r}"
+            )
+
+        digests = wheel.get("digests")
+        if not isinstance(digests, dict):
+            raise MalformedMetadataError("PyPI wheel digests must be an object")
+
         return cls(
-            schema_version=sv,
-            latest_version=_require_str(d, "latest_version"),
-            released_at=_require_str(d, "released_at"),
-            wheel_url=_require_str(d, "wheel_url"),
-            min_supported=_require_str(d, "min_supported"),
-            disabled=_require_str_list(d, "disabled"),
-            notice=_optional_str(d, "notice", ""),
-            sha256=_require_sha256(d, "sha256"),
+            schema_version=_SCHEMA_VERSION,
+            latest_version=latest_version,
+            released_at=_optional_str(wheel, "upload_time_iso_8601", ""),
+            wheel_url=_require_str(wheel, "url"),
+            min_supported="0",
+            disabled=(),
+            notice="",
+            sha256=_require_sha256(digests, "sha256"),
         )
 
     def to_json(self) -> str:
@@ -209,9 +192,9 @@ class LatestMetadata:
 
 def _base_url() -> str:
     """Return the metadata base URL, env-overridable. Trailing slash is
-    stripped so callers can do ``base + '/latest.json'`` uniformly.
+    stripped so callers can derive the metadata document uniformly.
 
-    Validates scheme (must be https) and host (must be in allowlist).
+    Validates scheme (must be https) and host (must be PyPI).
     Raises ValueError if the URL is not trusted.
     """
     raw = os.environ.get("MCS_UPDATE_BASE_URL", DEFAULT_BASE_URL)
@@ -224,19 +207,40 @@ def _base_url() -> str:
             f"MCS_UPDATE_BASE_URL must use https (got {parsed.scheme}://); "
             f"refusing to fetch metadata over insecure transport"
         )
-    if parsed.hostname not in _ALLOWED_HOSTS and not _truthy_env(
-        "MCS_ALLOW_UNTRUSTED_UPDATE_BASE_URL"
-    ):
+    if parsed.hostname not in _ALLOWED_HOSTS:
         raise ValueError(
             f"MCS_UPDATE_BASE_URL host {parsed.hostname!r} is not in the "
-            f"trusted allowlist {sorted(_ALLOWED_HOSTS)}; unset it to use the default "
-            f"or set MCS_ALLOW_UNTRUSTED_UPDATE_BASE_URL=1 for a deliberate HTTPS mirror"
+            f"trusted allowlist {sorted(_ALLOWED_HOSTS)}; unset it to use PyPI"
         )
     return url
 
 
+def _metadata_url() -> str:
+    """Return the concrete metadata document URL.
+
+    The default PyPI publisher uses ``/pypi/maxcompute-semantic/json``.
+    ``MCS_UPDATE_BASE_URL`` may point at ``https://pypi.org`` or that
+    exact project path, with or without the trailing ``/json``.
+    """
+    from urllib.parse import urlparse
+
+    base = _base_url()
+    parsed = urlparse(base)
+    path = parsed.path.rstrip("/")
+    if not path:
+        return f"https://{_PYPI_HOST}{_PYPI_PROJECT_PATH}/json"
+    if path == _PYPI_PROJECT_PATH:
+        return f"{base}/json"
+    if path == f"{_PYPI_PROJECT_PATH}/json":
+        return base
+    raise ValueError(
+        "MCS_UPDATE_BASE_URL must point at the PyPI project JSON base "
+        f"for maxcompute-semantic (got {base!r})"
+    )
+
+
 def fetch_latest_metadata(timeout_s: float = 5.0) -> LatestMetadata | None:
-    """Synchronously fetch and parse ``<base>/latest.json``.
+    """Synchronously fetch and parse the publisher metadata document.
 
     Returns the parsed ``LatestMetadata`` on success, or ``None`` on
     any failure: DNS resolution, connection refused, non-2xx HTTP
@@ -252,8 +256,8 @@ def fetch_latest_metadata(timeout_s: float = 5.0) -> LatestMetadata | None:
     timeout because urllib's timeout applies to the whole connection
     lifecycle once the request starts.
 
-    The base URL comes from ``MCS_UPDATE_BASE_URL`` (default
-    ``DEFAULT_BASE_URL``); see ``_base_url``. We intentionally don't
+    The metadata URL comes from ``MCS_UPDATE_BASE_URL`` (default
+    ``DEFAULT_BASE_URL``); see ``_metadata_url``. We intentionally don't
     use ``requests`` here — stdlib ``urllib.request`` is one less
     dependency in the wheel, and the surface is one GET with no auth.
 
@@ -267,17 +271,26 @@ def fetch_latest_metadata(timeout_s: float = 5.0) -> LatestMetadata | None:
     import urllib.request
 
     try:
-        url = f"{_base_url()}/latest.json"
+        url = _metadata_url()
+        from maxcompute_semantic import __version__
+
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": _PYPI_USER_AGENT.format(version=__version__),
+            },
+        )
         # urlopen's ``timeout`` argument covers both connect and read.
         # The default global socket timeout is None (block forever) on
         # Python, so this argument is the only thing standing between
-        # mcs and an unbounded hang if OSS becomes unreachable mid-TCP.
-        with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+        # mcs and an unbounded hang if PyPI becomes unreachable mid-TCP.
+        with urllib.request.urlopen(request, timeout=timeout_s) as resp:
             # urlopen raises HTTPError for >=400, so by here status is
             # 2xx. We still defensively read up to a sane cap so a
-            # misconfigured OSS object serving a multi-GB file can't
-            # OOM us. 64 KiB is comfortably larger than any plausible
-            # latest.json (~250 bytes).
+            # A bad endpoint serving a multi-GB file can't OOM us.
+            # 64 KiB is comfortably larger than PyPI's project JSON
+            # for this package.
             raw = resp.read(64 * 1024)
     except (urllib.error.URLError, OSError, TimeoutError, ValueError):
         # URLError covers DNS, connection refused, TLS handshake fail,
@@ -301,14 +314,13 @@ def fetch_latest_metadata(timeout_s: float = 5.0) -> LatestMetadata | None:
         return None
 
     try:
-        return LatestMetadata.from_dict(parsed)
+        return LatestMetadata.from_pypi_dict(parsed)
     except UpdateCheckError:
-        # Covers both UnsupportedSchemaError and MalformedMetadataError —
-        # the daemon thread should not crash because the publisher
-        # rolled out a bad latest.json. The doctor checks below
-        # distinguish "no metadata" (network) from "bad metadata"
-        # (publisher) by re-issuing the fetch and inspecting the
-        # exception path. Banner stays silent in both cases.
+        # The daemon thread should not crash because PyPI returned a
+        # shape we cannot normalize. The doctor checks below
+        # distinguish "no metadata" (network) from "bad metadata" by
+        # re-issuing the fetch and inspecting the exception path.
+        # Banner stays silent in both cases.
         return None
 
 
@@ -863,8 +875,8 @@ def format_banner(cache: CacheEntry | None, *, current: str) -> str | None:
       * The soft form (one-line "new release available: cur → new.
         Run mcs update to upgrade.") otherwise.
 
-    A non-empty ``notice`` field from the publisher's ``latest.json``
-    is prepended to the line, separated by ``" — "``, so a
+    A non-empty normalized ``notice`` field is prepended to the line,
+    separated by ``" — "``, so a
     publisher-side announcement ("CVE patched in 0.4.0a40") rides
     the same channel as the version arrow. The notice can be the
     whole message in cases where there's no version delta (the

--- a/src/maxcompute_semantic/commands/doctor.py
+++ b/src/maxcompute_semantic/commands/doctor.py
@@ -37,7 +37,7 @@ from maxcompute_semantic._internal.paths import (
 from maxcompute_semantic._internal.update_check import (
     CacheEntry,
     LatestMetadata,
-    _base_url,
+    _metadata_url,
     fetch_latest_metadata,
     is_disabled,
     write_cache,
@@ -825,7 +825,6 @@ def _run_update_check_fetch() -> tuple[LatestMetadata | None, str]:
     from maxcompute_semantic._internal.update_check import (
         LatestMetadata as _LM,
         MalformedMetadataError,
-        UnsupportedSchemaError,
     )
 
     md = fetch_latest_metadata()
@@ -833,7 +832,10 @@ def _run_update_check_fetch() -> tuple[LatestMetadata | None, str]:
         # Re-issue to capture the exception class for the message.
         # Same timeout; the second probe is in the noise compared to
         # the first one's timeout already elapsing.
-        url = f"{_base_url()}/latest.json"
+        try:
+            url = _metadata_url()
+        except ValueError as e:
+            return (None, str(e))
         try:
             with urllib.request.urlopen(url, timeout=5.0) as resp:
                 _body = resp.read(64 * 1024)
@@ -850,10 +852,8 @@ def _run_update_check_fetch() -> tuple[LatestMetadata | None, str]:
         # pull a discriminating error.
         try:
             parsed = json.loads(_body.decode("utf-8"))
-            _LM.from_dict(parsed)
+            _LM.from_pypi_dict(parsed)
             return (None, f"{url} response shape is not the expected metadata")
-        except UnsupportedSchemaError as e:
-            return (None, f"unsupported schema_version: {e}")
         except MalformedMetadataError as e:
             return (None, f"malformed metadata: {e}")
         except Exception as e:
@@ -880,13 +880,18 @@ def _check_update_channel_reachable(
     summary and a remediation pointer at the ``MCS_UPDATE_BASE_URL``
     env var override.
     """
+    def _metadata_url_for_message() -> str:
+        with contextlib.suppress(ValueError):
+            return _metadata_url()
+        return "PyPI update metadata endpoint"
+
     md, err = fetch_result
     if md is None:
         return (
             "update_channel",
             "fail",
             (
-                f"could not reach {_base_url()}/latest.json: {err}. "
+                f"could not reach {_metadata_url_for_message()}: {err}. "
                 f"Override with MCS_UPDATE_BASE_URL or check connectivity "
                 f"(corporate proxy / DNS). The banner and the auto-upgrade "
                 f"flow both read from this endpoint."
@@ -895,7 +900,7 @@ def _check_update_channel_reachable(
     return (
         "update_channel",
         "pass",
-        f"{_base_url()}/latest.json reachable; latest_version={md.latest_version}",
+        f"{_metadata_url_for_message()} reachable; latest_version={md.latest_version}",
     )
 
 
@@ -1001,11 +1006,11 @@ def doctor_cmd(ctx: click.Context, profile: str | None, offline: bool) -> None:
     tier, build data, skill installation, update channel reachable,
     update version current.
 
-    The two update checks share one HTTP fetch of
-    ``MCS_UPDATE_BASE_URL/latest.json`` (default OSS host); the
+    The two update checks share one HTTP fetch of the publisher
+    metadata document (default PyPI project JSON); the
     channel-reachable check is the "network up" verdict, the
-    version-current check is the "is this version on the publisher's
-    disabled list / behind min_supported / behind latest" verdict.
+    version-current check is the "is this version disabled / behind
+    min_supported / behind latest" verdict.
     The combined fetch result is also written to the update-check
     cache, so the next foreground mcs command's banner reflects the
     same state without firing its own probe.

--- a/src/maxcompute_semantic/commands/sql.py
+++ b/src/maxcompute_semantic/commands/sql.py
@@ -727,15 +727,16 @@ def cost_cmd(pctx: ProfileContext, sql: str) -> None:
     the JSON payload). On error, exits with the classified exit_code
     (4 for auth failures, 5 for permission/not-found).
     """
+    stripped_sql, set_hints = _split_or_emit(sql)
     client = None
     try:
-        target_project = _route_project(pctx.project_override, pctx.profile.name, sql)
+        target_project = _route_project(pctx.project_override, pctx.profile.name, stripped_sql)
         client = make_client_for_project(target_project, profile_name=pctx.profile.name)
         tier = get_tier(client.profile, client.profile.compute_project, client=client)
         schema = resolve_schema_for_tier(tier, pctx.schema_override, profile=client.profile)
-        result = client.cost_estimate(sql, schema=schema)
+        result = client.cost_estimate(stripped_sql, schema=schema, hints=set_hints or None)
     except McsError as e:
-        _emit_mcs_error(sql, client.profile if client is not None else pctx.profile, e)
+        _emit_mcs_error(stripped_sql, client.profile if client is not None else pctx.profile, e)
 
     emit_status(result)
 
@@ -767,15 +768,16 @@ def explain_cmd(
     Runs EXPLAIN <sql> and returns the plan text.
     Tier resolution is automatic (3-level projects get namespace/schema hints).
     """
+    stripped_sql, set_hints = _split_or_emit(sql)
     client = None
     try:
-        target_project = _route_project(project, profile, sql)
+        target_project = _route_project(project, profile, stripped_sql)
         client = make_client_for_project(target_project, profile_name=profile)
         tier = get_tier(client.profile, client.profile.compute_project, client=client)
         schema = resolve_schema_for_tier(tier, schema, profile=client.profile)
-        result = client.explain(sql, timeout=timeout, schema=schema)
+        result = client.explain(stripped_sql, timeout=timeout, schema=schema, hints=set_hints or None)
     except McsError as e:
-        _emit_mcs_error(sql, client.profile if client is not None else None, e)
+        _emit_mcs_error(stripped_sql, client.profile if client is not None else None, e)
 
     emit_status(result)
 

--- a/src/maxcompute_semantic/commands/sql.py
+++ b/src/maxcompute_semantic/commands/sql.py
@@ -326,10 +326,10 @@ def _guard_sql_execution(sql: str, profile: str | None, *, allow_write: bool) ->
 def _split_or_emit(sql: str) -> tuple[str, dict[str, str]]:
     """Extract SET→hints; emit+exit if the SQL is only SETs (no query).
 
-    Shared by the ``mcs sql execute`` / ``submit`` verbs so the write guard,
-    project routing, cost gate, and pyodps submission all see the SET-free
-    SQL and the extracted hints. (``cost`` / ``explain`` / ``review`` are
-    wired separately.) A standalone ``SET k=v`` (no query) is rejected with
+    Shared by every ``mcs sql`` verb (execute / submit / cost / explain /
+    review) so the write guard, project routing, cost gate, and pyodps
+    submission all see the SET-free SQL and the extracted hints. A
+    standalone ``SET k=v`` (no query) is rejected with
     ``WriteOpRejectedError`` because there is nothing to execute. If the SQL
     cannot be tokenized, ``split_set_hints`` returns it unchanged and the
     downstream write guard classifies it as ``unparseable`` (friendly
@@ -486,7 +486,7 @@ def execute_cmd(
         # (sql wait / sql result) instead of resubmitting the query.
         instance_id = str(e.context.get("instance_id") or "")
         if client is None or not instance_id:
-            _emit_mcs_error(sql, client.profile if client is not None else None, e)
+            _emit_mcs_error(stripped_sql, client.profile if client is not None else None, e)
             return  # _emit_mcs_error is NoReturn (sys.exit); this is for readers + linters
         try:
             status = client.get_instance_status(instance_id)
@@ -510,7 +510,8 @@ def execute_cmd(
         emit_status(status)
         return
     except McsError as e:
-        _emit_mcs_error(sql, client.profile if client is not None else None, e)
+        _emit_mcs_error(stripped_sql, client.profile if client is not None else None, e)
+
 
     # Emit the envelope dict as JSON on stdout.
     print(json.dumps(envelope.to_dict(), ensure_ascii=False))
@@ -577,7 +578,7 @@ def submit_cmd(
                 "status_probe_error": status_error.to_envelope()["error"],
             }
     except McsError as e:
-        _emit_mcs_error(sql, client.profile if client is not None else None, e)
+        _emit_mcs_error(stripped_sql, client.profile if client is not None else None, e)
 
     emit_status(result)
 

--- a/src/maxcompute_semantic/commands/sql.py
+++ b/src/maxcompute_semantic/commands/sql.py
@@ -85,6 +85,7 @@ from maxcompute_semantic.mc_client.sql_guard import (
 from maxcompute_semantic.mc_client.sql_guard import (
     last_parse_error as _last_parse_error,
 )
+from maxcompute_semantic.mc_client.sql_preprocess import split_set_hints
 from maxcompute_semantic.mc_client.tier import get_tier
 
 if TYPE_CHECKING:
@@ -322,6 +323,35 @@ def _guard_sql_execution(sql: str, profile: str | None, *, allow_write: bool) ->
     _emit_mcs_error(sql, profile_obj, exc)
 
 
+def _split_or_emit(sql: str) -> tuple[str, dict[str, str]]:
+    """Extract SET→hints; emit+exit if the SQL is only SETs (no query).
+
+    Shared by the ``mcs sql execute`` / ``submit`` verbs so the write guard,
+    project routing, cost gate, and pyodps submission all see the SET-free
+    SQL and the extracted hints. (``cost`` / ``explain`` / ``review`` are
+    wired separately.) A standalone ``SET k=v`` (no query) is rejected with
+    ``WriteOpRejectedError`` because there is nothing to execute. If the SQL
+    cannot be tokenized, ``split_set_hints`` returns it unchanged and the
+    downstream write guard classifies it as ``unparseable`` (friendly
+    parse-error remediation, e.g. the doubled-quote hint).
+    """
+    stripped_sql, set_hints = split_set_hints(sql)
+    if not stripped_sql.strip():
+        _emit_mcs_error(
+            sql,
+            None,
+            WriteOpRejectedError(
+                "SQL contained only SET statements with no query; nothing to execute",
+                remediation=(
+                    "add a SELECT/INSERT/... statement after the SET, or remove "
+                    "the SET if you only meant to set a session property"
+                ),
+                sql=sql,
+            ),
+        )
+    return stripped_sql, set_hints
+
+
 def _client_and_schema_for_sql(
     project: str | None,
     profile: str | None,
@@ -434,14 +464,16 @@ def execute_cmd(
 
     Output: the Envelope JSON on stdout.
     """
-    _guard_sql_execution(sql, profile, allow_write=allow_write)
+    stripped_sql, set_hints = _split_or_emit(sql)
+    _guard_sql_execution(stripped_sql, profile, allow_write=allow_write)
 
     client = None
     try:
-        client, schema = _client_and_schema_for_sql(project, profile, schema, sql)
+        client, schema = _client_and_schema_for_sql(project, profile, schema, stripped_sql)
         envelope = client.execute_sql(
-            sql,
+            stripped_sql,
             schema=schema,
+            hints=set_hints or None,
             assume_yes=assume_yes,
             max_rows=max_rows,
             result_offset=result_offset,
@@ -523,14 +555,16 @@ def submit_cmd(
     sql: str,
 ) -> None:
     """Submit SQL asynchronously and return the MaxCompute instance ID."""
-    _guard_sql_execution(sql, profile, allow_write=allow_write)
+    stripped_sql, set_hints = _split_or_emit(sql)
+    _guard_sql_execution(stripped_sql, profile, allow_write=allow_write)
 
     client = None
     try:
-        client, schema = _client_and_schema_for_sql(project, profile, schema, sql)
+        client, schema = _client_and_schema_for_sql(project, profile, schema, stripped_sql)
         instance_id = client.run_sql_async(
-            sql,
+            stripped_sql,
             schema=schema,
+            hints=set_hints or None,
             assume_yes=assume_yes,
             allow_write=allow_write,
         )

--- a/src/maxcompute_semantic/commands/sql.py
+++ b/src/maxcompute_semantic/commands/sql.py
@@ -814,6 +814,7 @@ def review_cmd(
     )
     from maxcompute_semantic.mc_client.envelope import Envelope
 
+    stripped_sql, _set_hints = _split_or_emit(sql)
     profile_obj: Profile | None = None
     try:
         profile_obj = resolve_profile_for_project(project, profile_name=profile)
@@ -823,9 +824,9 @@ def review_cmd(
         # ``profile_obj`` is consumed downstream by ``build_review_envelope``,
         # ``get_tier``, and ``_emit_mcs_error``; the duplicate resolution
         # inside ``_route_project`` is the trade-off siblings already accept.
-        target_project = _route_project(project, profile, sql)
+        target_project = _route_project(project, profile, stripped_sql)
     except McsError as e:
-        _emit_mcs_error(sql, profile_obj, e)
+        _emit_mcs_error(stripped_sql, profile_obj, e)
     assert profile_obj is not None
 
     # Refuse writes / unparseable. The dispatcher would happily run rules
@@ -834,10 +835,10 @@ def review_cmd(
     # spec §5.4 refusal contract for the CLI seam folds both into one
     # MCS_REVIEW_UNSUPPORTED envelope so the agent can branch on
     # ``classification`` rather than parsing per-rule emit lists.
-    verdict = _classify_sql(sql)
+    verdict = _classify_sql(stripped_sql)
     if verdict != "read":
         _emit_mcs_error(
-            sql,
+            stripped_sql,
             profile_obj,
             ReviewUnsupportedError(
                 f"mcs sql review is read-only; got SQL classified as {verdict!r}",
@@ -867,7 +868,7 @@ def review_cmd(
     tier = get_tier(profile_obj, tier_project, allow_live_probe=False)
 
     data = build_review_envelope(
-        sql=sql,
+        sql=stripped_sql,
         profile=profile_obj,
         project=target_project,
         schema_name=schema,

--- a/src/maxcompute_semantic/commands/update.py
+++ b/src/maxcompute_semantic/commands/update.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024-2026, Alibaba Cloud and its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
-"""``mcs update`` — pull the latest wheel from OSS and reinstall in place.
+"""``mcs update`` — resolve the latest PyPI version and reinstall in place.
 
 The command picks the right installer based on how mcs is currently
 installed:
@@ -9,19 +9,17 @@ installed:
   * **uv tool install** (``uv tool install maxcompute-semantic``)
     — the bin shim and the tool venv live under
     ``~/.local/share/uv/tools/<package>/``. Upgrade command:
-    ``uv tool install --reinstall <wheel-url>``. uv parses the wheel
-    filename to identify the package, so the package name is
-    baked into the URL — we don't need to spell it out separately.
+    ``uv tool install --reinstall <install-target>``.
   * **pipx install** (``pipx install maxcompute-semantic``) — venvs
     under ``~/.local/pipx/venvs/<package>/``. Upgrade command:
-    ``pipx install --force <wheel-url>``.
+    ``pipx install --force <install-target>``.
   * **pip --user** (``pip install --user maxcompute-semantic``) — the
     console_script lands in ``site.getuserbase() + '/bin/'`` and
     ``sys.executable`` is the system Python. Upgrade command:
-    ``<sys.executable> -m pip install --user --upgrade <wheel-url>``.
+    ``<sys.executable> -m pip install --user --upgrade <install-target>``.
   * **pip into a venv or system Python** — everything else that has
     a known Python interpreter. Upgrade command:
-    ``<sys.executable> -m pip install --upgrade <wheel-url>``.
+    ``<sys.executable> -m pip install --upgrade <install-target>``.
   * **UNKNOWN** — the install layout doesn't match any of the above
     patterns. The command prints a manual-remediation hint and exits
     non-zero rather than guessing.
@@ -65,7 +63,6 @@ from maxcompute_semantic import __version__
 from maxcompute_semantic._internal.update_check import (
     CacheEntry,
     LatestMetadata,
-    _base_url,
     fetch_latest_metadata,
     write_cache,
 )
@@ -189,23 +186,18 @@ def detect_install_mode() -> InstallMode:
     return InstallMode.UNKNOWN
 
 
-def build_upgrade_argv(mode: InstallMode, *, wheel_url: str) -> list[str] | None:
+def build_upgrade_argv(mode: InstallMode, *, install_target: str) -> list[str] | None:
     """Return the argv list for the installer subprocess, or ``None``
     when the mode is ``UNKNOWN`` (the caller is expected to print
     a manual remediation line and exit non-zero in that case).
 
-    The wheel URL is positional and the same for every mode — both
-    ``uv tool install`` and ``pip install --upgrade`` accept a wheel
-    URL directly as the requirement specifier, and parse the wheel
-    filename for the package name (PEP 427). That means the URL
-    encodes the version, which is how the ``mcs update
-    --version <pinned>`` flag works: the caller rewrites the URL
-    path to point at the older wheel filename, hands the result
-    here, and the installer pulls the pinned wheel.
+    The install target is positional and the same for every mode. It
+    is a PyPI requirement specifier (``maxcompute-semantic==N``).
+    Keeping the target as a package requirement lets uv/pipx/pip apply
+    their configured indexes, mirrors, and resolver settings.
 
     The argv is the list form for ``subprocess.run(..., shell=False)``
-    so URL characters that would otherwise need shell-quoting (the
-    ``+`` in PEP 440 local version segments, for instance) are passed
+    so characters that would otherwise need shell-quoting are passed
     through unmangled. The ``--reinstall`` (uv) / ``--force`` (pipx)
     flags handle the "already-installed at the same version" case so
     a ``mcs update --version <current>`` no-op still re-runs the
@@ -230,20 +222,18 @@ def build_upgrade_argv(mode: InstallMode, *, wheel_url: str) -> list[str] | None
     """
     py = sys.executable or "python3"
     if mode is InstallMode.UV_TOOL:
-        # `uv tool install <url>` parses the wheel filename for the
-        # package name, registers the tool by that name (so subsequent
-        # `uv tool list` etc. find it), and replaces the venv contents
-        # in place. `--reinstall` makes the operation idempotent
-        # against a same-version no-op. See uv docs:
+        # `uv tool install <target>` accepts a package requirement,
+        # registers the tool by package name, and replaces the venv
+        # contents in place. `--reinstall` makes the operation
+        # idempotent against a same-version no-op. See uv docs:
         # https://docs.astral.sh/uv/concepts/tools/#installing-tools.
-        return ["uv", "tool", "install", "--reinstall", wheel_url]
+        return ["uv", "tool", "install", "--reinstall", install_target]
     if mode is InstallMode.PIPX:
-        # pipx's analogous flag is `--force`. The package name is
-        # parsed from the wheel filename the same way uv does it.
-        return ["pipx", "install", "--force", wheel_url]
+        # pipx's analogous flag is `--force`.
+        return ["pipx", "install", "--force", install_target]
     if mode is InstallMode.PIP_USER:
-        # `<python> -m pip install --user --upgrade <url>` matches the
-        # invocation the user typed at install time. `--upgrade`
+        # `<python> -m pip install --user --upgrade <requirement>` matches
+        # the invocation the user typed at install time. `--upgrade`
         # forces a same-version reinstall via pip's resolver. The
         # user-site bin dir already contains the `mcs` console_script
         # symlink/wrapper from the original install; pip rewrites it
@@ -256,49 +246,40 @@ def build_upgrade_argv(mode: InstallMode, *, wheel_url: str) -> list[str] | None
             "install",
             "--user",
             "--upgrade",
-            wheel_url,
+            install_target,
         ]
     if mode is InstallMode.PIP:
         # The fall-through pip case — system pip or a venv. The
         # interpreter is the same one that imported this module, so
         # `pip` resolves to the same prefix the original install used.
-        return [py, "-m", "pip", "install", "--upgrade", wheel_url]
+        return [py, "-m", "pip", "install", "--upgrade", install_target]
     # UNKNOWN: the caller prints the manual hint.
     assert mode is InstallMode.UNKNOWN, f"unhandled InstallMode {mode!r}"
     return None
 
 
-def manual_upgrade_hint(wheel_url: str) -> str:
+def manual_upgrade_hint(install_target: str) -> str:
     """Multi-line text the caller prints when ``detect_install_mode``
     came back ``UNKNOWN``. Lists the four canonical commands so the
     user can pick the one that matches their install method. The
-    URL is interpolated into each command. Returns a string ending
+    target is interpolated into each command. Returns a string ending
     without a trailing newline."""
     py = shlex.quote(sys.executable or "python3")
-    url = shlex.quote(wheel_url)
+    target = shlex.quote(install_target)
     lines = [
         "Could not detect how mcs was installed — please pick one of:",
-        f"  uv tool install --reinstall {url}",
-        f"  pipx install --force {url}",
-        f"  {py} -m pip install --upgrade {url}",
-        f"  {py} -m pip install --user --upgrade {url}",
+        f"  uv tool install --reinstall {target}",
+        f"  pipx install --force {target}",
+        f"  {py} -m pip install --upgrade {target}",
+        f"  {py} -m pip install --user --upgrade {target}",
         "Then run `mcs --version` to confirm.",
     ]
     return "\n".join(lines)
 
 
-def _wheel_url_for_version(version: str) -> str:
-    """Construct the canonical wheel URL for a pinned version.
-
-    The publisher uploads wheels under ``<base>/wheels/<filename>``
-    where the filename is the PEP 427-normalized form
-    ``maxcompute_semantic-<version>-py3-none-any.whl`` (hyphens in
-    the package name become underscores). The ``--version`` CLI flag
-    on ``mcs update`` accepts a PEP 440 version string verbatim and
-    feeds it through here. No validation is done up front — if the
-    version doesn't exist on OSS the install subprocess will fail
-    with a 404 and the user sees the installer's stderr."""
-    return f"{_base_url()}/wheels/maxcompute_semantic-{version}-py3-none-any.whl"
+def _install_target_for_version(version: str) -> str:
+    """Return the installer target for an explicit ``--version`` pin."""
+    return f"maxcompute-semantic=={version}"
 
 
 def _resolve_target_metadata(pinned: str | None) -> LatestMetadata | str | None:
@@ -308,20 +289,18 @@ def _resolve_target_metadata(pinned: str | None) -> LatestMetadata | str | None:
 
       * ``LatestMetadata`` — the publisher's metadata when no
         ``--version`` was supplied. The caller uses
-        ``metadata.wheel_url`` (which may differ from the
-        constructed URL if the publisher relocated wheels — e.g.
-        moved to PyPI). And ``metadata.disabled`` /
-        ``metadata.min_supported`` are consulted for the
-        "running version is itself disabled" edge case.
+        ``metadata.latest_version`` to build a package requirement,
+        letting the installer resolve the actual wheel from its
+        configured package indexes.
       * A bare ``str`` — the user's ``--version <pinned>`` value.
-        The wheel URL is built locally; the publisher's metadata is
-        bypassed entirely, so the version-pin path also works when
-        ``latest.json`` is unreachable. The disabled/min_supported
+        The install target is built locally; the publisher's metadata
+        is bypassed entirely, so the version-pin path also works when
+        update metadata is unreachable. The disabled/min_supported
         guard doesn't apply (the user is explicitly asking for a
         specific version, presumably to *escape* a bad latest).
       * ``None`` — the fetch failed and no pin was given.
         ``cmd_update`` prints the canonical "could not fetch
-        ``latest.json``" message and exits non-zero.
+        update metadata" message and exits non-zero.
     """
     if pinned is not None:
         return pinned
@@ -412,22 +391,18 @@ def _final_verify_exec_unix(argv0: str) -> None:
     metavar="VERSION",
     help=(
         "Pin a specific PEP 440 version (e.g. 0.4.0a40). "
-        "When set, the publisher's latest.json is bypassed and the "
-        "wheel URL is constructed locally — useful for downgrades or "
+        "When set, the publisher metadata fetch is bypassed and the "
+        "install target is constructed locally — useful for downgrades or "
         "for installing a release the publisher hasn't yet announced."
     ),
 )
 def cmd_update(check: bool, target_version: str | None) -> None:
-    """Pull the latest mcs wheel and reinstall in place.
+    """Resolve the target mcs version and reinstall in place.
 
     The installer is picked from how the running mcs was originally
     installed — ``uv tool install``, ``pipx install``, or
-    ``pip install --user`` / plain ``pip install``. The wheel URL
-    comes from ``MCS_UPDATE_BASE_URL/wheels/maxcompute_semantic-
-    <version>-py3-none-any.whl`` (default base
-    ``https://maxcompute-semantic.oss-cn-beijing.aliyuncs.com``), so
-    the same command works for a PyPI move later by flipping the
-    base URL via env var.
+    ``pip install --user`` / plain ``pip install``. The default
+    publisher metadata comes from PyPI.
 
     After the install, the skill bundle is re-linked in every agent
     slot (``mcs skill update --all``) so Claude Code / Codex /
@@ -456,10 +431,8 @@ def cmd_update(check: bool, target_version: str | None) -> None:
 
     Environment variables consumed:
 
-      * ``MCS_UPDATE_BASE_URL`` — overrides the OSS base URL. The
-        same variable is read by the metadata fetcher; the wheel URL
-        construction here uses the same base so a custom mirror
-        works end-to-end.
+      * ``MCS_UPDATE_BASE_URL`` — overrides the PyPI project metadata
+        base URL. Only ``pypi.org`` project JSON endpoints are trusted.
     """
     current = __version__
     click.echo(f"Current mcs version: {current}", err=True)
@@ -467,9 +440,9 @@ def cmd_update(check: bool, target_version: str | None) -> None:
     target = _resolve_target_metadata(target_version)
     if target is None:
         raise click.ClickException(
-            "Could not fetch latest.json metadata and no --version pin "
+            "Could not fetch PyPI update metadata and no --version pin "
             "was given. Check network connectivity to the publisher "
-            "base URL (MCS_UPDATE_BASE_URL or the default OSS host); "
+            "base URL (MCS_UPDATE_BASE_URL or the default PyPI endpoint); "
             "see `mcs doctor` for the channel-reachable probe."
         )
 
@@ -486,37 +459,19 @@ def cmd_update(check: bool, target_version: str | None) -> None:
                 f"re-run `mcs update` when a new version lands."
             )
 
-        # The publisher's wheel URL is the authority — could differ
-        # from the locally-constructed URL if wheels live somewhere
-        # else (the PyPI migration seam). For the OSS host, the URL
-        # in the metadata equals the constructed URL.
+        # PyPI project JSON is the authority for latest_version. The
+        # installer still gets a package requirement instead of the
+        # artifact URL, so mirrors and installer index settings are
+        # respected for the actual download.
         target_version_str = target.latest_version
-        wheel_url = target.wheel_url
-        sha256_expected = target.sha256
-        # Validate the URL starts with the trusted base URL and contains
-        # the version string — not just a substring check.
-        from maxcompute_semantic._internal.update_check import _base_url
-
-        expected_prefix = _base_url() + "/wheels/"
-        expected_wheel_url = _wheel_url_for_version(target_version_str)
-        if not wheel_url.startswith(expected_prefix):
-            raise click.ClickException(
-                f"latest.json wheel_url={wheel_url!r} does not start with "
-                f"trusted base URL {expected_prefix!r}; refusing to install."
-            )
-        if wheel_url != expected_wheel_url:
-            raise click.ClickException(
-                f"latest.json wheel_url={wheel_url!r} does not match the "
-                f"canonical wheel URL {expected_wheel_url!r}; refusing to install."
-            )
+        install_target = _install_target_for_version(target_version_str)
         # Refresh the cache so the next foreground mcs sees the same
         # state and the soft banner reflects "we just learned of N+1".
         _stamp_cache_after_fetch(target)
     else:
         assert isinstance(target, str)
         target_version_str = target
-        wheel_url = _wheel_url_for_version(target_version_str)
-        sha256_expected = ""
+        install_target = _install_target_for_version(target_version_str)
 
     if target_version_str == current:
         click.echo(f"Already on the latest version of mcs ({current}).", err=True)
@@ -524,59 +479,26 @@ def cmd_update(check: bool, target_version: str | None) -> None:
 
     mode = detect_install_mode()
     if mode is InstallMode.UNKNOWN:
-        click.echo(manual_upgrade_hint(wheel_url), err=True)
+        click.echo(manual_upgrade_hint(install_target), err=True)
         sys.exit(1)
 
-    argv = build_upgrade_argv(mode, wheel_url=wheel_url)
+    argv = build_upgrade_argv(mode, install_target=install_target)
     assert argv is not None  # UNKNOWN already handled above.
 
     click.echo(
         f"Upgrading mcs from {current} → {target_version_str} via {mode.value}.",
         err=True,
     )
-    click.echo(f"  Wheel: {wheel_url}", err=True)
+    click.echo(f"  Source: {install_target}", err=True)
     click.echo(f"  Command: {' '.join(shlex.quote(a) for a in argv)}", err=True)
 
     if check:
         click.confirm("Proceed with upgrade?", default=False, abort=True, err=True)
 
-    # SHA256 verification: if the publisher included a hash in
-    # latest.json, download the wheel to a temp file, verify the
-    # digest, then replace the remote URL in argv with the local path.
-    if sha256_expected:
-        import hashlib
-        import tempfile
-        import urllib.request
-
-        click.echo("  Verifying SHA256 digest...", err=True)
-        with tempfile.NamedTemporaryFile(suffix=".whl", delete=False) as tmp:
-            tmp_path = tmp.name
-        try:
-            urllib.request.urlretrieve(wheel_url, tmp_path)
-            with open(tmp_path, "rb") as f:
-                actual = hashlib.sha256(f.read()).hexdigest()
-            if actual != sha256_expected:
-                os.unlink(tmp_path)
-                raise click.ClickException(
-                    f"SHA256 mismatch: expected {sha256_expected}, got {actual}. "
-                    f"The wheel at {wheel_url} may have been tampered with; "
-                    f"refusing to install."
-                )
-            click.echo(f"  SHA256 OK: {actual}", err=True)
-            argv = [a if a != wheel_url else tmp_path for a in argv]
-        except urllib.error.URLError as e:
-            os.unlink(tmp_path)
-            raise click.ClickException(
-                f"Failed to download wheel for SHA256 verification: {e}"
-            ) from e
-
-    # Run the installer. ``capture_output=True`` keeps the user's
-    # terminal clean and lets us prefix the installer's stderr with
-    # context on failure. ``check=False`` so we control the exit
+    # Run the installer. ``capture_output=False`` keeps pip/uv/pipx
+    # progress visible. ``check=False`` lets us control the exit
     # behavior instead of subprocess raising CalledProcessError.
     result = subprocess.run(argv, capture_output=False, check=False)
-    if sha256_expected and os.path.exists(tmp_path):
-        os.unlink(tmp_path)
     if result.returncode != 0:
         raise click.ClickException(
             f"Installer ``{argv[0]}`` exited {result.returncode}. "

--- a/src/maxcompute_semantic/mc_client/sql_preprocess.py
+++ b/src/maxcompute_semantic/mc_client/sql_preprocess.py
@@ -43,7 +43,14 @@ def split_set_hints(sql: str) -> tuple[str, dict[str, str]]:
     """
     hints: list[tuple[str, str]] = []
     kept: list[str] = []
-    toks = MaxCompute.Tokenizer().tokenize(sql)
+    try:
+        toks = MaxCompute.Tokenizer().tokenize(sql)
+    except sqlglot.errors.TokenError:
+        # Malformed SQL (e.g. unmatched quotes) cannot be tokenized; fall back
+        # to the original SQL with no hints so the caller's write guard /
+        # classifier can emit its friendly parse-error remediation instead of
+        # crashing. Keeps this function total for every caller.
+        return sql, {}
     semi_ends = [t.end for t in toks if t.token_type is TokenType.SEMICOLON]
     bounds = [-1, *semi_ends, len(sql)]
     for i in range(len(bounds) - 1):

--- a/src/maxcompute_semantic/mc_client/sql_preprocess.py
+++ b/src/maxcompute_semantic/mc_client/sql_preprocess.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2024-2026, Alibaba Cloud and its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract ``SET key=val`` statements into pyodps hints.
+
+Called by the ``mcs sql`` verbs before the write guard and cost gate, so
+``SET k=v; SELECT ...`` scripts run transparently (classified as the
+remaining statement) instead of being rejected as a write or blocked by
+the cost gate's ``execute_sql_cost`` (which, unlike ``run_sql``, does not
+strip SET to hints).
+"""
+
+from __future__ import annotations
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.tokens import TokenType
+
+from maxcompute_semantic.dialect import MaxCompute, parse_mc
+
+
+def split_set_hints(sql: str) -> tuple[str, dict[str, str]]:
+    """Extract ``SET key=val`` statements into hints.
+
+    Returns ``(sql_without_sets, hints)``. Uses the MaxCompute sqlglot
+    tokenizer to split the SQL into verbatim statement segments at
+    top-level semicolons (string- and comment-aware, so ``;`` inside a
+    literal or ``--`` comment is not a separator). Each segment is parsed
+    with ``parse_mc``; segments that parse to an assignment ``Set`` whose
+    every ``SetItem`` is an ``EQ`` (not ``UNSET``/tag, not a bare flag)
+    become hints and are dropped; all other segments (SELECT/DDL, and
+    ``SET LABEL`` which parses as a ``Command``) are kept verbatim and
+    rejoined.
+
+    Non-SET SQL is preserved verbatim (no AST regeneration): the MaxCompute
+    sqlglot generator rewrites functions (verified lossy: ``TO_CHAR(d,
+    fmt)`` -> ``CAST(d AS STRING)`` losing the format string, ``SUBSTRING``
+    -> ``SUBSTR``), which would change the user's SQL semantics. key/val
+    are read from the ``Set`` AST (``SetItem.this.this`` is the key,
+    ``.expression`` the value); boolean values normalize to
+    ``TRUE``/``FALSE`` (MaxCompute is case-insensitive on these) while
+    other literal forms round-trip.
+    """
+    hints: list[tuple[str, str]] = []
+    kept: list[str] = []
+    toks = MaxCompute.Tokenizer().tokenize(sql)
+    semi_ends = [t.end for t in toks if t.token_type is TokenType.SEMICOLON]
+    bounds = [-1, *semi_ends, len(sql)]
+    for i in range(len(bounds) - 1):
+        segment = sql[bounds[i] + 1 : bounds[i + 1]].strip()
+        if not segment:
+            continue
+        try:
+            stmts = parse_mc(segment, error_level=sqlglot.ErrorLevel.IGNORE)
+        except Exception:
+            stmts = []
+        stmt = stmts[0] if stmts else None
+        if (
+            isinstance(stmt, exp.Set)
+            and not stmt.args.get("unset")
+            and not stmt.args.get("tag")
+        ):
+            items = stmt.args.get("expressions") or []
+            eqs = [it for it in items if isinstance(it.this, exp.EQ)]
+            if eqs and len(eqs) == len(items):
+                for it in eqs:
+                    eq = it.this
+                    k = eq.this.sql(dialect="maxcompute")
+                    v = eq.expression.sql(dialect="maxcompute")
+                    hints.append((k, v))
+                continue
+        kept.append(segment)
+    if not hints:
+        # Nothing extracted -> return the ORIGINAL sql verbatim (newlines /
+        # formatting between statements preserved), not a "; "-rejoined copy.
+        return sql, {}
+    return "; ".join(kept), dict(hints)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,10 +178,50 @@ def fixtures_dir() -> Path:
 
 
 @pytest.fixture
-def latest_json_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def pypi_project_payload():
+    """Factory for the PyPI project JSON shape returned by
+    ``https://pypi.org/pypi/maxcompute-semantic/json``."""
+
+    def factory(
+        version: str = "9.9.9",
+        *,
+        sha256: str = "a" * 64,
+        wheel_url: str | None = None,
+        upload_time: str = "2026-06-22T15:45:27.936944Z",
+        yanked: bool = False,
+    ) -> dict[str, object]:
+        wheel_filename = f"maxcompute_semantic-{version}-py3-none-any.whl"
+        return {
+            "info": {"version": version},
+            "urls": [
+                {
+                    "filename": f"maxcompute_semantic-{version}.tar.gz",
+                    "packagetype": "sdist",
+                    "url": f"https://files.pythonhosted.org/packages/source/{version}.tar.gz",
+                    "digests": {"sha256": "b" * 64},
+                    "upload_time_iso_8601": upload_time,
+                    "yanked": False,
+                },
+                {
+                    "filename": wheel_filename,
+                    "packagetype": "bdist_wheel",
+                    "url": wheel_url
+                    or f"https://files.pythonhosted.org/packages/py3/{wheel_filename}",
+                    "digests": {"sha256": sha256},
+                    "upload_time_iso_8601": upload_time,
+                    "yanked": yanked,
+                },
+            ],
+        }
+
+    return factory
+
+
+@pytest.fixture
+def pypi_json_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Stand up a stdlib HTTP server on a random port that serves a
-    settable ``/latest.json`` payload, point
-    ``MCS_UPDATE_BASE_URL`` at it, and yield a control handle.
+    settable PyPI project JSON payload, patch the update metadata URL
+    to point at it, and yield a control handle.
 
     Also redirects ``MCS_CACHE_DIR`` to a per-test tmpdir so any test
     that triggers ``start_background_probe`` (e.g. ``mcs doctor``,
@@ -208,8 +248,7 @@ def latest_json_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     The fixture is intentionally stdlib-only (no ``pytest-httpserver``
     dependency) — the test surface is one endpoint with no header /
-    content-negotiation requirements. See spec
-    §"Testing strategy / Stub server for tests"."""
+    content-negotiation requirements."""
     import socketserver
     from http.server import BaseHTTPRequestHandler
     from threading import Thread
@@ -222,7 +261,7 @@ def latest_json_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             return
 
         def do_GET(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler interface)
-            if self.path != "/latest.json":
+            if self.path != "/pypi/maxcompute-semantic/json":
                 self.send_error(404, "not found")
                 return
             payload = state["payload"]
@@ -262,26 +301,18 @@ def latest_json_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     thread.start()
 
     base_url = f"http://{host}:{port}"
-    monkeypatch.setenv("MCS_UPDATE_BASE_URL", base_url)
-    # Relax _base_url() validation for the test-local HTTP server:
-    # allow http scheme and the 127.0.0.1 host.
+    metadata_url = f"{base_url}/pypi/maxcompute-semantic/json"
+
     import maxcompute_semantic._internal.update_check as _uc
 
-    monkeypatch.setattr(_uc, "_ALLOWED_HOSTS", frozenset({*_uc._ALLOWED_HOSTS, str(host)}))
+    def _test_metadata_url() -> str:
+        return metadata_url
 
-    def _test_base_url() -> str:
-        import os as _os
-
-        raw = _os.environ.get("MCS_UPDATE_BASE_URL", _uc.DEFAULT_BASE_URL).rstrip("/")
-        return raw
-
-    monkeypatch.setattr(_uc, "_base_url", _test_base_url)
-    # Also patch modules that import _base_url by name at the top level.
+    monkeypatch.setattr(_uc, "_metadata_url", _test_metadata_url)
+    # Also patch modules that import _metadata_url by name at the top level.
     import maxcompute_semantic.commands.doctor as _doc
-    import maxcompute_semantic.commands.update as _upd
 
-    monkeypatch.setattr(_doc, "_base_url", _test_base_url)
-    monkeypatch.setattr(_upd, "_base_url", _test_base_url)
+    monkeypatch.setattr(_doc, "_metadata_url", _test_metadata_url)
     # Also sandbox the on-disk update-check cache. ``mcs doctor`` and
     # ``mcs update`` both fire ``start_background_probe(force=True)``
     # which calls ``write_cache(...)`` regardless of the test's

--- a/tests/unit/_internal/test_update_check.py
+++ b/tests/unit/_internal/test_update_check.py
@@ -12,116 +12,69 @@ from __future__ import annotations
 
 import dataclasses
 import json
-import os
 from pathlib import Path
 
 import pytest
 
 
 class TestLatestMetadata:
-    def test_parse_full_payload(self) -> None:
+    def test_parse_pypi_payload(self, pypi_project_payload) -> None:
         from maxcompute_semantic._internal.update_check import LatestMetadata
 
-        raw = {
-            "schema_version": 1,
-            "latest_version": "0.4.0a40",
-            "released_at": "2026-05-22T12:00:00Z",
-            "wheel_url": "https://example.test/wheels/x.whl",
-            "min_supported": "0.4.0a30",
-            "disabled": ["0.4.0a32", "0.4.0a35"],
-            "notice": "scheduled maintenance",
-            "sha256": "A" * 64,
-        }
-        m = LatestMetadata.from_dict(raw)
+        raw = pypi_project_payload("0.17.3", sha256="A" * 64)
+        m = LatestMetadata.from_pypi_dict(raw)
         assert m.schema_version == 1
-        assert m.latest_version == "0.4.0a40"
-        assert m.released_at == "2026-05-22T12:00:00Z"
-        assert m.wheel_url == "https://example.test/wheels/x.whl"
-        assert m.min_supported == "0.4.0a30"
-        assert m.disabled == ("0.4.0a32", "0.4.0a35")
-        assert m.notice == "scheduled maintenance"
-        assert m.sha256 == "a" * 64
-
-    def test_parse_minimal_payload(self) -> None:
-        """Optional fields default to empty values."""
-        from maxcompute_semantic._internal.update_check import LatestMetadata
-
-        m = LatestMetadata.from_dict(
-            {
-                "schema_version": 1,
-                "latest_version": "0.4.0a40",
-                "released_at": "2026-05-22T12:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "min_supported": "0.4.0a30",
-                "disabled": [],
-                "sha256": "a" * 64,
-                "notice": "",
-            }
+        assert m.latest_version == "0.17.3"
+        assert m.released_at == "2026-06-22T15:45:27.936944Z"
+        assert m.wheel_url == (
+            "https://files.pythonhosted.org/packages/py3/"
+            "maxcompute_semantic-0.17.3-py3-none-any.whl"
         )
+        assert m.min_supported == "0"
         assert m.disabled == ()
         assert m.notice == ""
         assert m.sha256 == "a" * 64
 
-    def test_parse_missing_sha256_field(self) -> None:
-        """Remote latest.json must carry a wheel digest."""
+    def test_parse_missing_sha256_field(self, pypi_project_payload) -> None:
+        """PyPI project JSON must carry the wheel digest."""
         from maxcompute_semantic._internal.update_check import (
             LatestMetadata,
             MalformedMetadataError,
         )
 
+        raw = pypi_project_payload("0.17.3")
+        wheel = raw["urls"][1]
+        assert isinstance(wheel, dict)
+        digests = wheel["digests"]
+        assert isinstance(digests, dict)
+        del digests["sha256"]
+
         with pytest.raises(MalformedMetadataError, match="sha256"):
-            LatestMetadata.from_dict(
-                {
-                    "schema_version": 1,
-                    "latest_version": "0.4.0a40",
-                    "released_at": "2026-05-22T12:00:00Z",
-                    "wheel_url": "https://example.test/wheels/x.whl",
-                    "min_supported": "0.4.0a30",
-                    "disabled": [],
-                    "notice": "",
-                }
-            )
+            LatestMetadata.from_pypi_dict(raw)
 
     @pytest.mark.parametrize("sha256", ["abc123", "g" * 64])
-    def test_parse_rejects_malformed_sha256_field(self, sha256: str) -> None:
-        """Remote latest.json must carry a full hex SHA256 digest."""
+    def test_parse_rejects_malformed_sha256_field(
+        self, sha256: str, pypi_project_payload
+    ) -> None:
+        """PyPI project JSON must carry a full hex SHA256 digest."""
         from maxcompute_semantic._internal.update_check import (
             LatestMetadata,
             MalformedMetadataError,
         )
 
         with pytest.raises(MalformedMetadataError, match="SHA256"):
-            LatestMetadata.from_dict(
-                {
-                    "schema_version": 1,
-                    "latest_version": "0.4.0a40",
-                    "released_at": "2026-05-22T12:00:00Z",
-                    "wheel_url": "https://example.test/wheels/x.whl",
-                    "min_supported": "0.4.0a30",
-                    "disabled": [],
-                    "notice": "",
-                    "sha256": sha256,
-                }
-            )
+            LatestMetadata.from_pypi_dict(pypi_project_payload("0.17.3", sha256=sha256))
 
-    def test_parse_rejects_unknown_schema_version(self) -> None:
+    def test_parse_rejects_missing_matching_wheel(self, pypi_project_payload) -> None:
         from maxcompute_semantic._internal.update_check import (
             LatestMetadata,
-            UnsupportedSchemaError,
+            MalformedMetadataError,
         )
 
-        with pytest.raises(UnsupportedSchemaError):
-            LatestMetadata.from_dict(
-                {
-                    "schema_version": 99,
-                    "latest_version": "0.4.0a40",
-                    "released_at": "2026-05-22T12:00:00Z",
-                    "wheel_url": "https://example.test/wheels/x.whl",
-                    "min_supported": "0.4.0a30",
-                    "disabled": [],
-                    "notice": "",
-                }
-            )
+        raw = pypi_project_payload("0.17.3", yanked=True)
+
+        with pytest.raises(MalformedMetadataError, match="no non-yanked wheel"):
+            LatestMetadata.from_pypi_dict(raw)
 
     def test_parse_missing_required_field(self) -> None:
         from maxcompute_semantic._internal.update_check import (
@@ -130,77 +83,66 @@ class TestLatestMetadata:
         )
 
         with pytest.raises(MalformedMetadataError):
-            LatestMetadata.from_dict({"schema_version": 1})  # missing the rest
+            LatestMetadata.from_pypi_dict({"urls": []})  # missing info.version
 
 
-class TestLatestJsonServer:
+class TestPyPIJsonServer:
     """Sanity check the fixture itself — every test that exercises
     fetch_latest_metadata depends on it."""
 
-    def test_serves_dict_payload(self, latest_json_server) -> None:
+    def test_serves_dict_payload(self, pypi_json_server) -> None:
         import urllib.request
 
-        base_url, setter = latest_json_server
+        base_url, setter = pypi_json_server
         setter({"hello": "world"})
-        with urllib.request.urlopen(f"{base_url}/latest.json", timeout=2.0) as r:
+        with urllib.request.urlopen(f"{base_url}/pypi/maxcompute-semantic/json", timeout=2.0) as r:
             body = r.read().decode("utf-8")
         assert json.loads(body) == {"hello": "world"}
 
-    def test_serves_500_status(self, latest_json_server) -> None:
+    def test_serves_500_status(self, pypi_json_server) -> None:
         import urllib.error
         import urllib.request
 
-        base_url, setter = latest_json_server
+        base_url, setter = pypi_json_server
         setter(503)
         with pytest.raises(urllib.error.HTTPError) as ei:
-            urllib.request.urlopen(f"{base_url}/latest.json", timeout=2.0)
+            urllib.request.urlopen(f"{base_url}/pypi/maxcompute-semantic/json", timeout=2.0)
         assert ei.value.code == 503
 
 
 class TestFetchLatestMetadata:
-    _VALID_PAYLOAD = {
-        "schema_version": 1,
-        "latest_version": "0.4.0a40",
-        "released_at": "2026-05-22T12:00:00Z",
-        "wheel_url": "https://example.test/wheels/x.whl",
-        "sha256": "a" * 64,
-        "min_supported": "0.4.0a30",
-        "disabled": [],
-        "notice": "",
-    }
-
-    def test_returns_metadata_on_200(self, latest_json_server) -> None:
+    def test_returns_metadata_on_200(self, pypi_json_server, pypi_project_payload) -> None:
         from maxcompute_semantic._internal.update_check import (
             LatestMetadata,
             fetch_latest_metadata,
         )
 
-        _, setter = latest_json_server
-        setter(self._VALID_PAYLOAD)
+        _, setter = pypi_json_server
+        setter(pypi_project_payload("0.4.0a40"))
         result = fetch_latest_metadata(timeout_s=2.0)
         assert isinstance(result, LatestMetadata)
         assert result.latest_version == "0.4.0a40"
 
-    def test_returns_none_on_5xx(self, latest_json_server) -> None:
+    def test_returns_none_on_5xx(self, pypi_json_server) -> None:
         from maxcompute_semantic._internal.update_check import fetch_latest_metadata
 
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(503)
         assert fetch_latest_metadata(timeout_s=2.0) is None
 
-    def test_returns_none_on_invalid_json(self, latest_json_server) -> None:
+    def test_returns_none_on_invalid_json(self, pypi_json_server) -> None:
         from maxcompute_semantic._internal.update_check import fetch_latest_metadata
 
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter("not-valid-json{{{")
         assert fetch_latest_metadata(timeout_s=2.0) is None
 
-    def test_returns_none_on_unsupported_schema(self, latest_json_server) -> None:
+    def test_returns_none_on_malformed_pypi_payload(self, pypi_json_server) -> None:
         from maxcompute_semantic._internal.update_check import fetch_latest_metadata
 
-        _, setter = latest_json_server
-        setter({**self._VALID_PAYLOAD, "schema_version": 99})
-        # UnsupportedSchemaError is raised by from_dict() and folded
+        _, setter = pypi_json_server
+        setter({"info": {"version": "0.17.3"}, "urls": []})
+        # MalformedMetadataError is raised by from_pypi_dict() and folded
         # into None by fetch_latest_metadata's catch-all.
         assert fetch_latest_metadata(timeout_s=2.0) is None
 
@@ -222,15 +164,13 @@ class TestFetchLatestMetadata:
 
         assert fetch_latest_metadata(timeout_s=0.5) is None
 
-    def test_uses_base_url_from_env(
-        self, latest_json_server, monkeypatch: pytest.MonkeyPatch
+    def test_uses_metadata_url_provider(
+        self, pypi_json_server, pypi_project_payload, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The fixture sets MCS_UPDATE_BASE_URL. Confirm the fetcher
-        actually reads it: serve a payload, then verify the parsed
-        result matches."""
-        base_url, setter = latest_json_server
-        setter({**self._VALID_PAYLOAD, "latest_version": "9.9.9"})
-        assert os.environ["MCS_UPDATE_BASE_URL"] == base_url
+        """The fixture patches the resolved metadata URL. Confirm the
+        fetcher uses that PyPI JSON endpoint."""
+        _, setter = pypi_json_server
+        setter(pypi_project_payload("9.9.9"))
 
         from maxcompute_semantic._internal.update_check import fetch_latest_metadata
 
@@ -238,44 +178,167 @@ class TestFetchLatestMetadata:
         assert result is not None
         assert result.latest_version == "9.9.9"
 
+    def test_parses_pypi_json_payload(
+        self, monkeypatch: pytest.MonkeyPatch, pypi_project_payload
+    ) -> None:
+        import json
+
+        from maxcompute_semantic._internal.update_check import (
+            LatestMetadata,
+            fetch_latest_metadata,
+        )
+
+        payload = pypi_project_payload(
+            "0.17.3",
+            wheel_url="https://files.pythonhosted.org/packages/w/wheel.whl",
+        )
+        called_urls: list[str] = []
+
+        class _Resp:
+            def __enter__(self) -> "_Resp":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self, _limit: int) -> bytes:
+                return json.dumps(payload).encode("utf-8")
+
+        def fake_urlopen(request, timeout: float):  # type: ignore[no-untyped-def]
+            called_urls.append(request.full_url)
+            return _Resp()
+
+        monkeypatch.delenv("MCS_UPDATE_BASE_URL", raising=False)
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+        result = fetch_latest_metadata(timeout_s=2.0)
+
+        assert isinstance(result, LatestMetadata)
+        assert called_urls == ["https://pypi.org/pypi/maxcompute-semantic/json"]
+        assert result.latest_version == "0.17.3"
+        assert result.released_at == "2026-06-22T15:45:27.936944Z"
+        assert result.wheel_url == "https://files.pythonhosted.org/packages/w/wheel.whl"
+        assert result.sha256 == "a" * 64
+        assert result.min_supported == "0"
+        assert result.disabled == ()
+
+    def test_pypi_json_request_identifies_mcs_user_agent(
+        self, monkeypatch: pytest.MonkeyPatch, pypi_project_payload
+    ) -> None:
+        import json
+
+        from maxcompute_semantic._internal.update_check import fetch_latest_metadata
+
+        payload = pypi_project_payload("0.17.3")
+        called_urls: list[str] = []
+        called_headers: list[dict[str, str]] = []
+
+        class _Resp:
+            def __enter__(self) -> "_Resp":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self, _limit: int) -> bytes:
+                return json.dumps(payload).encode("utf-8")
+
+        def fake_urlopen(request, timeout: float):  # type: ignore[no-untyped-def]
+            assert hasattr(request, "full_url")
+            called_urls.append(request.full_url)
+            called_headers.append({k.lower(): v for k, v in request.header_items()})
+            return _Resp()
+
+        monkeypatch.delenv("MCS_UPDATE_BASE_URL", raising=False)
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+        result = fetch_latest_metadata(timeout_s=2.0)
+
+        assert result is not None
+        assert called_urls == ["https://pypi.org/pypi/maxcompute-semantic/json"]
+        assert called_headers
+        user_agent = called_headers[0].get("user-agent", "")
+        assert user_agent.startswith("mcs/")
+        assert "maxcompute-semantic" in user_agent
+
 
 class TestBaseUrlValidation:
     def test_default_base_url_is_trusted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from maxcompute_semantic._internal.update_check import DEFAULT_BASE_URL, _base_url
 
         monkeypatch.delenv("MCS_UPDATE_BASE_URL", raising=False)
-        monkeypatch.delenv("MCS_ALLOW_UNTRUSTED_UPDATE_BASE_URL", raising=False)
 
         assert _base_url() == DEFAULT_BASE_URL
+        assert _base_url() == "https://pypi.org/pypi/maxcompute-semantic"
+
+    def test_pypi_host_is_trusted_without_escape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from maxcompute_semantic._internal.update_check import _base_url
+
+        monkeypatch.setenv("MCS_UPDATE_BASE_URL", "https://pypi.org")
+
+        assert _base_url() == "https://pypi.org"
+
+    @pytest.mark.parametrize(
+        ("base_url", "metadata_url"),
+        [
+            (
+                "https://pypi.org",
+                "https://pypi.org/pypi/maxcompute-semantic/json",
+            ),
+            (
+                "https://pypi.org/pypi/maxcompute-semantic",
+                "https://pypi.org/pypi/maxcompute-semantic/json",
+            ),
+            (
+                "https://pypi.org/pypi/maxcompute-semantic/json",
+                "https://pypi.org/pypi/maxcompute-semantic/json",
+            ),
+        ],
+    )
+    def test_metadata_url_normalizes_pypi_project_paths(
+        self, base_url: str, metadata_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from maxcompute_semantic._internal.update_check import _metadata_url
+
+        monkeypatch.setenv("MCS_UPDATE_BASE_URL", base_url)
+
+        assert _metadata_url() == metadata_url
 
     @pytest.mark.parametrize("url", ["http://example.test", "file:///tmp/latest"])
-    def test_rejects_non_https_scheme_even_with_escape(
+    def test_rejects_non_https_scheme(
         self, url: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from maxcompute_semantic._internal.update_check import _base_url
 
         monkeypatch.setenv("MCS_UPDATE_BASE_URL", url)
-        monkeypatch.setenv("MCS_ALLOW_UNTRUSTED_UPDATE_BASE_URL", "1")
 
         with pytest.raises(ValueError, match="https"):
             _base_url()
 
-    def test_rejects_untrusted_https_without_escape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://mirror.example.test/mcs",
+            "https://maxcompute-semantic.oss-cn-beijing.aliyuncs.com",
+        ],
+    )
+    def test_rejects_non_pypi_https(
+        self, url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from maxcompute_semantic._internal.update_check import _base_url
 
-        monkeypatch.setenv("MCS_UPDATE_BASE_URL", "https://mirror.example.test/mcs")
-        monkeypatch.delenv("MCS_ALLOW_UNTRUSTED_UPDATE_BASE_URL", raising=False)
+        monkeypatch.setenv("MCS_UPDATE_BASE_URL", url)
 
         with pytest.raises(ValueError, match="trusted allowlist"):
             _base_url()
 
-    def test_allows_untrusted_https_with_escape(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from maxcompute_semantic._internal.update_check import _base_url
+    def test_rejects_wrong_pypi_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from maxcompute_semantic._internal.update_check import _metadata_url
 
-        monkeypatch.setenv("MCS_UPDATE_BASE_URL", "https://mirror.example.test/mcs/")
-        monkeypatch.setenv("MCS_ALLOW_UNTRUSTED_UPDATE_BASE_URL", "1")
+        monkeypatch.setenv("MCS_UPDATE_BASE_URL", "https://pypi.org/simple")
 
-        assert _base_url() == "https://mirror.example.test/mcs"
+        with pytest.raises(ValueError, match="PyPI project JSON"):
+            _metadata_url()
 
 
 class TestIsDisabled:
@@ -287,7 +350,7 @@ class TestIsDisabled:
             schema_version=1,
             latest_version="0.4.0a99",
             released_at="2026-05-22T00:00:00Z",
-            wheel_url="https://example.test/wheels/x.whl",
+            wheel_url="https://files.pythonhosted.org/packages/py3/x.whl",
             min_supported=min_supported,
             disabled=disabled,
             notice="",
@@ -389,7 +452,7 @@ class TestCache:
             checked_at="2026-05-22T09:55:00Z",
             current_at_check="0.4.0a38",
             latest_version="0.4.0a40",
-            wheel_url="https://example.test/wheels/x.whl",
+            wheel_url="https://files.pythonhosted.org/packages/py3/x.whl",
             min_supported="0.4.0a30",
             disabled=("0.4.0a32",),
             notice="hello",
@@ -420,7 +483,7 @@ class TestCache:
             checked_at="2026-05-22T09:00:00Z",
             current_at_check="0.4.0a38",
             latest_version="0.4.0a39",
-            wheel_url="https://example.test/wheels/x.whl",
+            wheel_url="https://files.pythonhosted.org/packages/py3/x.whl",
             min_supported="0.4.0a30",
             disabled=(),
             notice="",
@@ -529,7 +592,7 @@ class TestFormatBanner:
             checked_at="2026-05-22T09:55:00Z",
             current_at_check="0.4.0a38",
             latest_version="0.4.0a40",
-            wheel_url="https://example.test/wheels/x.whl",
+            wheel_url="https://files.pythonhosted.org/packages/py3/x.whl",
             min_supported="0.4.0a30",
             disabled=(),
             notice="",
@@ -839,25 +902,15 @@ class TestBackgroundProbe:
 
     def test_run_probe_writes_successful_cache(
         self,
-        latest_json_server,
+        pypi_json_server,
         _cache_tmp: Path,
         monkeypatch: pytest.MonkeyPatch,
+        pypi_project_payload,
     ) -> None:
         """The synchronous probe routine (the body the daemon thread
         runs) populates the cache file from the served metadata."""
-        _, setter = latest_json_server
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "0.4.0a99",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.4.0a30",
-                "disabled": [],
-                "notice": "synced",
-            }
-        )
+        _, setter = pypi_json_server
+        setter(pypi_project_payload("0.4.0a99"))
 
         from maxcompute_semantic._internal.update_check import (
             _run_probe,
@@ -870,17 +923,17 @@ class TestBackgroundProbe:
         loaded = read_cache()
         assert loaded is not None
         assert loaded.latest_version == "0.4.0a99"
-        assert loaded.notice == "synced"
+        assert loaded.notice == ""
         assert loaded.fetch_error == ""
         assert loaded.current_at_check == "0.4.0a38"
         assert cache_path().exists()
 
     def test_run_probe_records_fetch_error_on_5xx(
         self,
-        latest_json_server,
+        pypi_json_server,
         _cache_tmp: Path,
     ) -> None:
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(503)
         from maxcompute_semantic._internal.update_check import _run_probe, read_cache
 
@@ -893,25 +946,15 @@ class TestBackgroundProbe:
 
     def test_run_probe_preserves_prior_on_transient_error(
         self,
-        latest_json_server,
+        pypi_json_server,
         _cache_tmp: Path,
+        pypi_project_payload,
     ) -> None:
         from maxcompute_semantic._internal.update_check import _run_probe, read_cache
 
         # First probe: successful.
-        _, setter = latest_json_server
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "0.4.0a99",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.4.0a30",
-                "disabled": [],
-                "notice": "",
-            }
-        )
+        _, setter = pypi_json_server
+        setter(pypi_project_payload("0.4.0a99"))
         _run_probe(current_version="0.4.0a38")
         good = read_cache()
         assert good is not None
@@ -931,31 +974,21 @@ class TestBackgroundProbe:
 
     def test_start_background_probe_returns_immediately(
         self,
-        latest_json_server,
+        pypi_json_server,
         _cache_tmp: Path,
+        pypi_project_payload,
     ) -> None:
         """The public entry point is non-blocking. We assert that by
         wrapping the probe body with a delay and confirming the spawn
         call returns before the delay would have completed."""
         import time
 
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         # Slow the server-side response by serving a payload that
         # takes a moment — the simplest knob is just the wall-clock of
         # the fetch when the server is up vs the wall-clock of the
         # spawn call, which should be sub-millisecond regardless.
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "0.4.0a99",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.4.0a30",
-                "disabled": [],
-                "notice": "",
-            }
-        )
+        setter(pypi_project_payload("0.4.0a99"))
 
         from maxcompute_semantic._internal.update_check import start_background_probe
 
@@ -983,7 +1016,7 @@ class TestBackgroundProbe:
 
     def test_start_background_probe_skips_when_ttl_fresh(
         self,
-        latest_json_server,
+        pypi_json_server,
         _cache_tmp: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -1007,7 +1040,7 @@ class TestBackgroundProbe:
                 checked_at=_utcnow_iso(),
                 current_at_check="0.4.0a38",
                 latest_version="0.4.0a40",
-                wheel_url="https://example.test/wheels/x.whl",
+                wheel_url="https://files.pythonhosted.org/packages/py3/x.whl",
                 min_supported="0.4.0a30",
                 disabled=(),
                 notice="",
@@ -1033,25 +1066,15 @@ class TestBackgroundProbe:
 
     def test_start_background_probe_force_bypasses_ttl(
         self,
-        latest_json_server,
+        pypi_json_server,
         _cache_tmp: Path,
         monkeypatch: pytest.MonkeyPatch,
+        pypi_project_payload,
     ) -> None:
         """``force=True`` (used by ``mcs doctor`` for a fresh probe)
         runs even when the cache is fresh."""
-        _, setter = latest_json_server
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "0.4.0a99",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.4.0a30",
-                "disabled": [],
-                "notice": "",
-            }
-        )
+        _, setter = pypi_json_server
+        setter(pypi_project_payload("0.4.0a99"))
 
         from maxcompute_semantic._internal.update_check import (
             CacheEntry,

--- a/tests/unit/commands/sql_review/test_review_cmd.py
+++ b/tests/unit/commands/sql_review/test_review_cmd.py
@@ -99,6 +99,37 @@ class TestSqlReviewCmd:
         # write vs unparseable when crafting the recovery prompt.
         assert out["error"]["context"]["classification"] == "write"
 
+    def test_set_then_select_is_reviewable(self, isolated_config: Path, make_review_package) -> None:
+        """SET key=val is extracted; the remaining SELECT is a read -> review runs."""
+        profile, _ = make_review_package(
+            tables=[
+                {
+                    "source_key": "rev_proj__default",
+                    "name": "orders",
+                    "columns": [{"name": "id"}],
+                },
+            ],
+        )
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            resolve_profile_for_project=MagicMock(return_value=profile),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                [
+                    "review",
+                    "--project",
+                    "rev_proj",
+                    "--schema",
+                    "default",
+                    "SET odps.sql.mapper.split.size = 4096; SELECT id FROM orders",
+                ]
+            )
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert out["status"] == "success"
+        assert out["data"]["sql"] == "SELECT id FROM orders"
+
     def test_review_profile_resolution_failure_returns_error_envelope(
         self, isolated_config: Path
     ) -> None:

--- a/tests/unit/commands/test_cli_root.py
+++ b/tests/unit/commands/test_cli_root.py
@@ -316,8 +316,7 @@ def test_banner_renders_on_stderr_when_cache_says_upgrade(
             current_at_check="0.4.0a38",
             latest_version="9.9.9",
             wheel_url=(
-                "https://maxcompute-semantic.oss-cn-beijing.aliyuncs.com/"
-                "wheels/maxcompute_semantic-9.9.9-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/py3/maxcompute_semantic-9.9.9-py3-none-any.whl"
             ),
             min_supported="0.4.0",
             disabled=(),
@@ -407,8 +406,7 @@ def test_hard_block_overrides_command_exit_code_to_2(
             current_at_check=__version__,
             latest_version="9.9.9",
             wheel_url=(
-                "https://maxcompute-semantic.oss-cn-beijing.aliyuncs.com/"
-                "wheels/maxcompute_semantic-9.9.9-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/py3/maxcompute_semantic-9.9.9-py3-none-any.whl"
             ),
             min_supported="9.0.0",
             disabled=(),
@@ -465,8 +463,7 @@ def test_banner_uses_sparkle_prefix_with_leading_newline(
             current_at_check="0.4.0a38",
             latest_version="9.9.9",
             wheel_url=(
-                "https://maxcompute-semantic.oss-cn-beijing.aliyuncs.com/"
-                "wheels/maxcompute_semantic-9.9.9-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/py3/maxcompute_semantic-9.9.9-py3-none-any.whl"
             ),
             min_supported="0.4.0",
             disabled=(),

--- a/tests/unit/commands/test_doctor_cmd.py
+++ b/tests/unit/commands/test_doctor_cmd.py
@@ -614,26 +614,15 @@ class TestUpdateChannelChecks:
     from click.testing import CliRunner
 
     def test_channel_pass_and_version_current_pass(
-        self, latest_json_server, isolated_config: Path
+        self, pypi_json_server, isolated_config: Path, pypi_project_payload
     ) -> None:
-        """latest.json is reachable and the running version >=
+        """PyPI project JSON is reachable and the running version >=
         latest_version → both checks PASS."""
         from maxcompute_semantic import __version__
         from maxcompute_semantic.commands.doctor import doctor_cmd
 
-        _, setter = latest_json_server
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": __version__,
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.0.1",
-                "disabled": [],
-                "notice": "",
-            }
-        )
+        _, setter = pypi_json_server
+        setter(pypi_project_payload(__version__))
 
         runner = self.CliRunner()
         result = runner.invoke(doctor_cmd, ["--offline"])
@@ -652,11 +641,11 @@ class TestUpdateChannelChecks:
         assert "update version" in out_lc
 
     def test_channel_fail_when_metadata_5xx(
-        self, latest_json_server, isolated_config: Path
+        self, pypi_json_server, isolated_config: Path
     ) -> None:
         from maxcompute_semantic.commands.doctor import doctor_cmd
 
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(503)
 
         runner = self.CliRunner()
@@ -672,7 +661,7 @@ class TestUpdateChannelChecks:
         assert "fail" in out_lc or "❌" in result.output
 
     def test_channel_pass_version_info_when_upgrade_available(
-        self, latest_json_server, isolated_config: Path
+        self, pypi_json_server, isolated_config: Path, pypi_project_payload
     ) -> None:
         """Channel reachable, but a newer version is published. The
         version check is an informational line — call it a "skip
@@ -681,19 +670,8 @@ class TestUpdateChannelChecks:
         from maxcompute_semantic import __version__
         from maxcompute_semantic.commands.doctor import doctor_cmd
 
-        _, setter = latest_json_server
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "9.9.9",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.0.1",
-                "disabled": [],
-                "notice": "",
-            }
-        )
+        _, setter = pypi_json_server
+        setter(pypi_project_payload("9.9.9"))
 
         runner = self.CliRunner()
         result = runner.invoke(doctor_cmd, [])
@@ -703,62 +681,6 @@ class TestUpdateChannelChecks:
         # has no profile, so profile_resolution fails → exit code 1.
         # The upgrade-available signal is informational and appears in
         # the output regardless.
-
-    def test_version_fails_when_running_is_disabled(
-        self, latest_json_server, isolated_config: Path
-    ) -> None:
-        """Disabled-list match → version check FAILs. Doctor exit code
-        is 1 (the standard "any fail" rule)."""
-        from maxcompute_semantic import __version__
-        from maxcompute_semantic.commands.doctor import doctor_cmd
-
-        _, setter = latest_json_server
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "9.9.9",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.0.1",
-                "disabled": [__version__],
-                "notice": "withdrawn for CVE-2026-1234",
-            }
-        )
-
-        runner = self.CliRunner()
-        result = runner.invoke(doctor_cmd, [])
-        out_lc = result.output.lower()
-        assert "disabled" in out_lc or "withdrawn" in out_lc or "cve-2026-1234" in out_lc
-        # ``mcs doctor`` exits 1 on any FAIL.
-        assert result.exit_code == 1
-
-    def test_version_fails_when_below_min_supported(
-        self, latest_json_server, isolated_config: Path
-    ) -> None:
-        from maxcompute_semantic.commands.doctor import doctor_cmd
-
-        _, setter = latest_json_server
-        # min_supported is way ahead of the running version, so
-        # current < min → FAIL.
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "9.9.9",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "9.0.0",
-                "disabled": [],
-                "notice": "",
-            }
-        )
-
-        runner = self.CliRunner()
-        result = runner.invoke(doctor_cmd, [])
-        out_lc = result.output.lower()
-        assert "min_supported" in out_lc or "minimum" in out_lc or "below" in out_lc
-        assert result.exit_code == 1
 
     def test_offline_skips_both_update_checks(self, isolated_config: Path) -> None:
         """``--offline`` short-circuits all network probes, including
@@ -776,9 +698,10 @@ class TestUpdateChannelChecks:
 
     def test_fetcher_called_once_when_both_checks_run(
         self,
-        latest_json_server,
+        pypi_json_server,
         isolated_config: Path,
         monkeypatch: pytest.MonkeyPatch,
+        pypi_project_payload,
     ) -> None:
         """The spec says the two checks share **one** fetch via a
         closure. We assert that by counting the wrapped
@@ -786,19 +709,8 @@ class TestUpdateChannelChecks:
         from maxcompute_semantic._internal import update_check as uc
         from maxcompute_semantic.commands import doctor as doc
 
-        _, setter = latest_json_server
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "0.0.1",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.0.0",
-                "disabled": [],
-                "notice": "",
-            }
-        )
+        _, setter = pypi_json_server
+        setter(pypi_project_payload("0.0.1"))
 
         counter = {"calls": 0}
         real = uc.fetch_latest_metadata
@@ -826,10 +738,11 @@ class TestUpdateChannelChecks:
 
     def test_doctor_warms_the_banner_cache(
         self,
-        latest_json_server,
+        pypi_json_server,
         tmp_path: Path,
         isolated_config: Path,
         monkeypatch: pytest.MonkeyPatch,
+        pypi_project_payload,
     ) -> None:
         """Side effect: after a successful doctor run, the update-check
         cache file is populated so the next foreground mcs command's
@@ -837,19 +750,8 @@ class TestUpdateChannelChecks:
         "doctor doubles as a cache warmup.")"""
         cdir = tmp_path / "cache"
         monkeypatch.setenv("MCS_CACHE_DIR", str(cdir))
-        _, setter = latest_json_server
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": "9.9.9",
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": "https://example.test/wheels/x.whl",
-                "sha256": "a" * 64,
-                "min_supported": "0.4.0",
-                "disabled": [],
-                "notice": "warmed by doctor",
-            }
-        )
+        _, setter = pypi_json_server
+        setter(pypi_project_payload("9.9.9"))
 
         from click.testing import CliRunner
         from maxcompute_semantic._internal.update_check import (
@@ -865,7 +767,7 @@ class TestUpdateChannelChecks:
         entry = read_cache()
         assert entry is not None
         assert entry.latest_version == "9.9.9"
-        assert entry.notice == "warmed by doctor"
+        assert entry.notice == ""
         assert entry.fetch_error == ""
 
 

--- a/tests/unit/commands/test_doctor_versioning_checks.py
+++ b/tests/unit/commands/test_doctor_versioning_checks.py
@@ -610,7 +610,7 @@ def test_inference_logic_check_ignores_unopenable_package_db(
 
 
 def test_update_channel_and_version_render_failure_and_skip() -> None:
-    fetch_result = (None, "HTTP 500 from https://example.test/latest.json")
+    fetch_result = (None, "HTTP 500 from https://pypi.org/pypi/maxcompute-semantic/json")
 
     channel = _check_update_channel_reachable(fetch_result)
     version = _check_update_version_current(fetch_result)
@@ -623,6 +623,20 @@ def test_update_channel_and_version_render_failure_and_skip() -> None:
         "skip",
         "skipped: update_channel check failed (see line above)",
     )
+
+
+def test_update_channel_failure_handles_invalid_metadata_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCS_UPDATE_BASE_URL", "https://pypi.org/simple")
+
+    channel = _check_update_channel_reachable(
+        (None, "MCS_UPDATE_BASE_URL must point at the PyPI project JSON base")
+    )
+
+    assert channel[0] == "update_channel"
+    assert channel[1] == "fail"
+    assert "PyPI project JSON" in (channel[2] or "")
 
 
 def test_update_version_pass_and_upgrade_available(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -664,7 +678,7 @@ def test_run_update_check_fetch_classifies_http_error(monkeypatch: pytest.Monkey
 
     def fake_urlopen(*args, **kwargs):
         raise urllib.error.HTTPError(
-            url="https://example.test/latest.json",
+            url="https://pypi.org/pypi/maxcompute-semantic/json",
             code=503,
             msg="unavailable",
             hdrs=None,

--- a/tests/unit/commands/test_mcs_update.py
+++ b/tests/unit/commands/test_mcs_update.py
@@ -119,7 +119,7 @@ class TestInstallMode:
 
 
 class TestBuildUpgradeArgv:
-    _URL = "https://maxcompute-semantic.oss-cn-beijing.aliyuncs.com/wheels/maxcompute_semantic-0.4.0a99-py3-none-any.whl"
+    _TARGET = "maxcompute-semantic==0.17.3"
 
     def test_uv_tool(self) -> None:
         from maxcompute_semantic.commands.update import (
@@ -127,8 +127,8 @@ class TestBuildUpgradeArgv:
             build_upgrade_argv,
         )
 
-        argv = build_upgrade_argv(InstallMode.UV_TOOL, wheel_url=self._URL)
-        assert argv == ["uv", "tool", "install", "--reinstall", self._URL]
+        argv = build_upgrade_argv(InstallMode.UV_TOOL, install_target=self._TARGET)
+        assert argv == ["uv", "tool", "install", "--reinstall", self._TARGET]
 
     def test_pipx(self) -> None:
         from maxcompute_semantic.commands.update import (
@@ -136,11 +136,11 @@ class TestBuildUpgradeArgv:
             build_upgrade_argv,
         )
 
-        assert build_upgrade_argv(InstallMode.PIPX, wheel_url=self._URL) == [
+        assert build_upgrade_argv(InstallMode.PIPX, install_target=self._TARGET) == [
             "pipx",
             "install",
             "--force",
-            self._URL,
+            self._TARGET,
         ]
 
     def test_pip_user_uses_current_python(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -150,14 +150,14 @@ class TestBuildUpgradeArgv:
             build_upgrade_argv,
         )
 
-        assert build_upgrade_argv(InstallMode.PIP_USER, wheel_url=self._URL) == [
+        assert build_upgrade_argv(InstallMode.PIP_USER, install_target=self._TARGET) == [
             "/usr/bin/python3.11",
             "-m",
             "pip",
             "install",
             "--user",
             "--upgrade",
-            self._URL,
+            self._TARGET,
         ]
 
     def test_pip(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -167,13 +167,13 @@ class TestBuildUpgradeArgv:
             build_upgrade_argv,
         )
 
-        assert build_upgrade_argv(InstallMode.PIP, wheel_url=self._URL) == [
+        assert build_upgrade_argv(InstallMode.PIP, install_target=self._TARGET) == [
             "/Users/a/work/.venv/bin/python",
             "-m",
             "pip",
             "install",
             "--upgrade",
-            self._URL,
+            self._TARGET,
         ]
 
     def test_unknown_returns_none(self) -> None:
@@ -182,41 +182,39 @@ class TestBuildUpgradeArgv:
             build_upgrade_argv,
         )
 
-        assert build_upgrade_argv(InstallMode.UNKNOWN, wheel_url=self._URL) is None
+        assert build_upgrade_argv(InstallMode.UNKNOWN, install_target=self._TARGET) is None
 
-    def test_target_version_pin_overrides_wheel_url(self) -> None:
+    def test_install_target_passes_through_verbatim(self) -> None:
         """The ``--version 0.4.0a50`` flag on ``mcs update`` rewrites
-        the wheel URL to that pinned version. The argv builder
-        takes the URL as input so the rewriting happens upstream;
-        we just confirm the builder is URL-shaped (i.e., passes the
-        URL through verbatim, no escape behavior)."""
+        the install target upstream. The argv builder just passes the
+        target through verbatim, with no shell escaping behavior."""
         from maxcompute_semantic.commands.update import (
             InstallMode,
             build_upgrade_argv,
         )
 
-        url_with_spaces = "https://example.test/wheels/x with space.whl"
-        argv = build_upgrade_argv(InstallMode.PIP, wheel_url=url_with_spaces)
+        target_with_spaces = "/tmp/maxcompute semantic/local wheel.whl"
+        argv = build_upgrade_argv(InstallMode.PIP, install_target=target_with_spaces)
         assert argv is not None
-        # The URL is the last positional. No shell quoting because we
+        # The target is the last positional. No shell quoting because we
         # don't run through a shell (subprocess.run with a list argv).
-        assert argv[-1] == url_with_spaces
+        assert argv[-1] == target_with_spaces
 
 
 class TestManualHint:
     def test_includes_all_four_installers(self) -> None:
         from maxcompute_semantic.commands.update import manual_upgrade_hint
 
-        hint = manual_upgrade_hint("https://example.test/wheels/x.whl")
+        hint = manual_upgrade_hint("maxcompute-semantic==0.17.3")
         assert "uv tool install" in hint
         assert "pipx install" in hint
         assert "-m pip install --upgrade" in hint
         assert "-m pip install --user --upgrade" in hint
-        # The URL is shell-quoted (single quotes around it because the
-        # default URL doesn't contain quote chars; this assertion is
-        # tolerant of the unquoted form for very plain URLs since
+        # The target is shell-quoted (single quotes around it because the
+        # default target doesn't contain quote chars; this assertion is
+        # tolerant of the unquoted form for very plain targets since
         # shlex.quote elides quotes when there's nothing to escape).
-        assert "x.whl" in hint
+        assert "maxcompute-semantic==0.17.3" in hint
 
 
 class TestCmdUpdate:
@@ -224,9 +222,9 @@ class TestCmdUpdate:
     and ``os.execvp`` are monkeypatched so no real process spawn
     occurs.
 
-    The fixtures from ``conftest.py`` (``latest_json_server``,
-    ``isolated_config``) carry the env-var plumbing — the test sets
-    a payload on the stub server and the command's fetcher hits it.
+    The fixtures from ``conftest.py`` (``pypi_json_server``,
+    ``isolated_config``) carry the PyPI JSON stub — the test sets a
+    payload on the stub server and the command's fetcher hits it.
     """
 
     from click.testing import CliRunner
@@ -276,40 +274,35 @@ class TestCmdUpdate:
         monkeypatch.setattr(upd, "detect_install_mode", lambda: upd.InstallMode.UV_TOOL)
 
     @pytest.fixture
-    def _ver_payload(self, latest_json_server, monkeypatch: pytest.MonkeyPatch):
-        """The standard latest.json shape pointing at a higher version
+    def _ver_payload(
+        self, pypi_project_payload, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The standard PyPI JSON shape pointing at a higher version
         than what the running mcs is at, so the command takes the
         upgrade path. The current mcs version is read at runtime
         via the version_for_test fixture below."""
-        import hashlib
         import urllib.request
 
-        base_url, _ = latest_json_server
-        wheel_sha256 = hashlib.sha256(b"").hexdigest()
+        class _PayloadFactory:
+            def __init__(self) -> None:
+                self.retrieved_urls: list[str] = []
+
+            def __call__(self, version: str = "0.4.0a99") -> dict:
+                return pypi_project_payload(version)
+
+        factory = _PayloadFactory()
 
         def fake_urlretrieve(url: str, filename: str):  # type: ignore[no-untyped-def]
-            Path(filename).write_bytes(b"")
-            return filename, None
+            factory.retrieved_urls.append(url)
+            raise AssertionError("mcs update should let the installer resolve package artifacts")
 
         monkeypatch.setattr(urllib.request, "urlretrieve", fake_urlretrieve)
-
-        def factory(version: str = "0.4.0a99") -> dict:
-            return {
-                "schema_version": 1,
-                "latest_version": version,
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": (f"{base_url}/wheels/maxcompute_semantic-{version}-py3-none-any.whl"),
-                "sha256": wheel_sha256,
-                "min_supported": "0.4.0",
-                "disabled": [],
-                "notice": "",
-            }
 
         return factory
 
     def test_already_on_latest_no_subprocess(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _no_real_exec: list[list[str]],
         _ver_payload,
@@ -320,7 +313,7 @@ class TestCmdUpdate:
         from maxcompute_semantic import __version__
         from maxcompute_semantic.commands.update import cmd_update
 
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         # Publisher's "latest" is exactly our version.
         setter(_ver_payload(__version__))
 
@@ -334,7 +327,7 @@ class TestCmdUpdate:
 
     def test_happy_path_uv_tool(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _no_real_exec: list[list[str]],
         _force_uv_tool_mode: None,
@@ -343,7 +336,7 @@ class TestCmdUpdate:
         """End-to-end: fetch metadata, build the uv argv, "run" the
         install subprocess, "run" the skill-update subprocess,
         "exec" the verification step."""
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(_ver_payload("9.9.9"))  # well ahead of the running version.
 
         from maxcompute_semantic.commands.update import cmd_update
@@ -359,9 +352,9 @@ class TestCmdUpdate:
         assert len(_no_real_subprocess) == 2
         installer_argv = _no_real_subprocess[0]
         assert installer_argv[:4] == ["uv", "tool", "install", "--reinstall"]
-        assert installer_argv[-1].endswith(".whl")
-        assert "/wheels/maxcompute_semantic-9.9.9-py3-none-any.whl" not in installer_argv[-1]
-        assert "SHA256 OK" in result.output
+        assert installer_argv[-1] == "maxcompute-semantic==9.9.9"
+        assert _ver_payload.retrieved_urls == []
+        assert "SHA256 OK" not in result.output
 
         skill_argv = _no_real_subprocess[1]
         # The skill-update call uses the script path that started us
@@ -378,7 +371,7 @@ class TestCmdUpdate:
 
     def test_post_install_prints_refresh_hint(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _no_real_exec: list[list[str]],
         _force_uv_tool_mode: None,
@@ -390,7 +383,7 @@ class TestCmdUpdate:
         it offline. The line lands on stderr (via ``err=True``) so it
         doesn't pollute scripted callers reading stdout, but the
         ``CliRunner`` collapses both streams into ``result.output``."""
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(_ver_payload("9.9.9"))
 
         from maxcompute_semantic.commands.update import cmd_update
@@ -404,7 +397,7 @@ class TestCmdUpdate:
 
     def test_check_prompt_no_aborts(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _no_real_exec: list[list[str]],
         _force_uv_tool_mode: None,
@@ -413,7 +406,7 @@ class TestCmdUpdate:
         """Without ``--no-check`` (i.e., with the default ``--check``),
         the command prompts for confirmation. Answering "n" aborts
         before any subprocess fires."""
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(_ver_payload("9.9.9"))
 
         from maxcompute_semantic.commands.update import cmd_update
@@ -431,13 +424,13 @@ class TestCmdUpdate:
 
     def test_check_prompt_yes_runs(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _no_real_exec: list[list[str]],
         _force_uv_tool_mode: None,
         _ver_payload,
     ) -> None:
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(_ver_payload("9.9.9"))
 
         from maxcompute_semantic.commands.update import cmd_update
@@ -450,16 +443,16 @@ class TestCmdUpdate:
 
     def test_version_pin_overrides_latest(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _no_real_exec: list[list[str]],
         _force_uv_tool_mode: None,
         _ver_payload,
     ) -> None:
         """``--version 0.4.0a50`` makes the installer pull that
-        specific wheel even though latest.json says something else."""
-        _, setter = latest_json_server
-        setter(_ver_payload("0.4.0a99"))
+        specific PyPI version spec even when the metadata endpoint is down."""
+        _, setter = pypi_json_server
+        setter(503)
 
         from maxcompute_semantic.commands.update import cmd_update
 
@@ -468,23 +461,46 @@ class TestCmdUpdate:
         assert result.exit_code == 0, result.output
         assert len(_no_real_subprocess) >= 1
         installer_argv = _no_real_subprocess[0]
-        url = installer_argv[-1]
-        # The URL path segment encodes the pinned version.
-        assert "0.4.0a50" in url
-        # And the "latest" 0.4.0a99 from the server isn't the install
-        # target.
-        assert "0.4.0a99" not in url
+        assert installer_argv[-1] == "maxcompute-semantic==0.4.0a50"
+
+    def test_version_pin_uses_pypi_package_spec_by_default(
+        self,
+        _no_real_subprocess: list[list[str]],
+        _no_real_exec: list[list[str]],
+        _force_uv_tool_mode: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The default publisher is PyPI, so an explicit version pin
+        should install a package requirement."""
+        monkeypatch.delenv("MCS_UPDATE_BASE_URL", raising=False)
+
+        from maxcompute_semantic.commands.update import cmd_update
+
+        runner = self.CliRunner()
+        result = runner.invoke(cmd_update, ["--no-check", "--version", "0.17.2"])
+
+        assert result.exit_code == 0, result.output
+        assert len(_no_real_subprocess) >= 1
+        installer_argv = _no_real_subprocess[0]
+        assert installer_argv == [
+            "uv",
+            "tool",
+            "install",
+            "--reinstall",
+            "maxcompute-semantic==0.17.2",
+        ]
+        assert _no_real_exec
 
     def test_metadata_fetch_failure_exits_one(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _no_real_exec: list[list[str]],
     ) -> None:
         """If the publisher's metadata endpoint is unreachable and the
         user didn't pin ``--version``, the command bails before
         spawning anything."""
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(503)
 
         from maxcompute_semantic.commands.update import cmd_update
@@ -497,22 +513,28 @@ class TestCmdUpdate:
         assert (
             "could not fetch" in out_lower
             or "unreachable" in out_lower
-            or "latest.json" in out_lower
+            or "pypi" in out_lower
         )
         assert _no_real_subprocess == []
         assert _no_real_exec == []
 
-    def test_latest_metadata_wheel_url_must_match_canonical_version_path(
+    def test_latest_update_lets_installer_resolve_distribution_source(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _no_real_exec: list[list[str]],
         _force_uv_tool_mode: None,
         _ver_payload,
     ) -> None:
-        base_url, setter = latest_json_server
+        """The no-pin path uses PyPI metadata only to learn the latest
+        version. The installer receives a package requirement, not the
+        PyPI artifact URL, so pip/uv/pipx index configuration and
+        mirrors remain in control of the actual distribution source."""
+        _, setter = pypi_json_server
         payload = _ver_payload("9.9.9")
-        payload["wheel_url"] = f"{base_url}/wheels/attacker-9.9.9-py3-none-any.whl"
+        wheel = payload["urls"][1]
+        assert isinstance(wheel, dict)
+        wheel["url"] = "https://example.test/packages/maxcompute_semantic-9.9.9-py3-none-any.whl"
         setter(payload)
 
         from maxcompute_semantic.commands.update import cmd_update
@@ -520,14 +542,14 @@ class TestCmdUpdate:
         runner = self.CliRunner()
         result = runner.invoke(cmd_update, ["--no-check"])
 
-        assert result.exit_code != 0
-        assert "canonical" in result.output.lower() or "refusing" in result.output.lower()
-        assert _no_real_subprocess == []
-        assert _no_real_exec == []
+        assert result.exit_code == 0, result.output
+        assert _no_real_subprocess[0][-1] == "maxcompute-semantic==9.9.9"
+        assert _ver_payload.retrieved_urls == []
+        assert _no_real_exec
 
     def test_installer_failure_exits_one_and_skips_skill_update_and_exec(
         self,
-        latest_json_server,
+        pypi_json_server,
         _force_uv_tool_mode: None,
         _ver_payload,
         monkeypatch: pytest.MonkeyPatch,
@@ -536,7 +558,7 @@ class TestCmdUpdate:
         prints the stderr and exits 1. The post-install
         ``skill update --all`` and the verifying ``--version`` exec
         do NOT run."""
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(_ver_payload("9.9.9"))
 
         import subprocess
@@ -577,11 +599,11 @@ class TestCmdUpdate:
 
     def test_unknown_install_mode_prints_manual_hint(
         self,
-        latest_json_server,
+        pypi_json_server,
         _ver_payload,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(_ver_payload("9.9.9"))
 
         from maxcompute_semantic.commands import update as upd
@@ -618,63 +640,13 @@ class TestCmdUpdate:
         assert "-m pip install --user --upgrade" in out
         assert run_calls == []
 
-    def test_disabled_version_blocks_update_at_the_same_version(
-        self,
-        latest_json_server,
-        _no_real_subprocess: list[list[str]],
-        _no_real_exec: list[list[str]],
-        _force_uv_tool_mode: None,
-    ) -> None:
-        """If the publisher pushed the *current* mcs version into the
-        ``disabled`` list (so the running version is disabled) AND
-        the published ``latest_version`` is what the user is running
-        right now, the command escalates the message: "running
-        version is disabled; the publisher has no replacement
-        wheel yet." Exit code is non-zero so a calling script
-        doesn't proceed.
-
-        This is an edge case from the spec's "Open questions / banner
-        cache GC" discussion of "latest is itself disabled."
-        """
-        from maxcompute_semantic import __version__
-        from maxcompute_semantic.commands.update import cmd_update
-
-        base_url, setter = latest_json_server
-        # latest_version == running version, and that version is on
-        # the disabled list.
-        setter(
-            {
-                "schema_version": 1,
-                "latest_version": __version__,
-                "released_at": "2026-05-22T00:00:00Z",
-                "wheel_url": (
-                    f"{base_url}/wheels/maxcompute_semantic-{__version__}-py3-none-any.whl"
-                ),
-                "sha256": "0" * 64,
-                "min_supported": "0.4.0",
-                "disabled": [__version__],
-                "notice": "the active latest wheel was withdrawn",
-            }
-        )
-
-        runner = self.CliRunner()
-        result = runner.invoke(cmd_update, ["--no-check"])
-        assert result.exit_code != 0
-        out = result.output.lower()
-        # Wording references the publisher state. The "no replacement
-        # available" hint is informative — the user can't upgrade
-        # past a withdrawn-latest just by re-running.
-        assert "disabled" in out or "withdrawn" in out or "no upgrade" in out
-        assert _no_real_subprocess == []
-        assert _no_real_exec == []
-
     @pytest.mark.skipif(
         sys.platform != "win32",
         reason="Windows-specific self-replace fallback",
     )
     def test_windows_skips_execvp_and_prints_restart_hint(
         self,
-        latest_json_server,
+        pypi_json_server,
         _no_real_subprocess: list[list[str]],
         _force_uv_tool_mode: None,
         _ver_payload,
@@ -691,7 +663,7 @@ class TestCmdUpdate:
         the manual smoke checklist in the spec's "Open questions /
         install.ps1 testing."
         """
-        _, setter = latest_json_server
+        _, setter = pypi_json_server
         setter(_ver_payload("9.9.9"))
 
         from maxcompute_semantic.commands import update as upd

--- a/tests/unit/commands/test_sql_cmd.py
+++ b/tests/unit/commands/test_sql_cmd.py
@@ -543,7 +543,7 @@ class TestSqlAsync:
         assert output["data"]["instance_id"] == "inst_123"
         assert output["data"]["status"] == "Running"
         mock_client.run_sql_async.assert_called_once_with(
-            "SELECT 1", schema="default", assume_yes=True, allow_write=False
+            "SELECT 1", schema="default", hints=None, assume_yes=True, allow_write=False
         )
         mock_client.execute_sql.assert_not_called()
 
@@ -2823,6 +2823,37 @@ class TestSqlExecuteWriteGuard:
         )
         assert result.exit_code == 0
         assert mock_client.execute_sql.called
+
+    def test_set_then_select_runs_without_allow_write(self, isolated_config: Path) -> None:
+        # SET key=val is extracted to a hint; the remaining SELECT is a read,
+        # so --allow-write is NOT required.
+        result, mock_client = self._run(
+            ["execute", "--project", "p", "--schema", "default",
+             "SET odps.sql.mapper.split.size = 4096; SELECT 1"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_client.execute_sql.called
+        call = mock_client.execute_sql.call_args
+        assert call.args[0] == "SELECT 1"
+        assert call.kwargs["hints"] == {"odps.sql.mapper.split.size": "4096"}
+
+    def test_set_label_still_requires_allow_write(self, isolated_config: Path) -> None:
+        # SET LABEL is not key=val -> not extracted -> stays -> rejected.
+        result, mock_client = self._run(
+            ["execute", "--project", "p", "--schema", "default",
+             "SET LABEL tbl TO user; SELECT 1"]
+        )
+        assert result.exit_code == 2
+        assert not mock_client.execute_sql.called
+
+    def test_standalone_set_is_rejected(self, isolated_config: Path) -> None:
+        result, mock_client = self._run(
+            ["execute", "--project", "p", "--schema", "default",
+             "SET odps.sql.mapper.split.size = 4096"]
+        )
+        assert result.exit_code == 2
+        assert not mock_client.execute_sql.called
+        assert "no query" in result.output
 
     def test_insert_default_rejected(self, isolated_config: Path) -> None:
         result, mock_client = self._run(

--- a/tests/unit/commands/test_sql_cmd.py
+++ b/tests/unit/commands/test_sql_cmd.py
@@ -2661,7 +2661,16 @@ class TestClassifySql:
         assert _classify_sql("USE my_db") == "read"
 
     def test_set_is_write(self) -> None:
-        """SET mutates session state — requires --allow-write."""
+        """SET mutates session state — requires --allow-write.
+
+        This stays 'write' on purpose: classify_sql is NOT modified by
+        the SET-extraction feature (see
+        docs/superpowers/specs/2026-06-23-set-statement-extraction-design.md).
+        Extraction happens in the verbs before classification, so
+        extractable SETs never reach classify_sql; non-extractable SETs
+        (SET LABEL, SETPROJECT) still do and must stay gated as write.
+        Do not remove this assertion.
+        """
         from maxcompute_semantic.commands.sql import _classify_sql
 
         assert _classify_sql("SET odps.sql.allow.fullscan=true") == "write"

--- a/tests/unit/commands/test_sql_cmd.py
+++ b/tests/unit/commands/test_sql_cmd.py
@@ -878,6 +878,39 @@ class TestSqlCost:
         output = json.loads(result.output)
         assert output["data"]["verdict"] == "blocked"
 
+    def test_cost_strips_set_and_passes_hints(self, isolated_config: Path) -> None:
+        """SET key=val is extracted to a hint; cost_estimate gets the stripped
+        SELECT + the SET as hints (so execute_sql_cost never sees the SET)."""
+        mock_profile = _mock_profile()
+        mock_client = _mock_client(mock_profile)
+        mock_client.cost_estimate.return_value = {
+            "estimated_input_bytes": 0,
+            "estimated_cost_cny": 0.0,
+            "verdict": "ok",
+            "thresholds": {"confirm_cny": 10.0, "blocked_cny": 100.0},
+        }
+
+        with patch.multiple(
+            "maxcompute_semantic.commands.sql",
+            make_client_for_project=MagicMock(return_value=mock_client),
+            get_tier=MagicMock(return_value="2"),
+        ):
+            result = _invoke(
+                [
+                    "cost",
+                    "--project",
+                    "my_proj",
+                    "--schema",
+                    "default",
+                    "SET odps.sql.mapper.split.size = 4096; SELECT * FROM t",
+                ]
+            )
+
+        assert result.exit_code == 0, result.output
+        call = mock_client.cost_estimate.call_args
+        assert call.args[0] == "SELECT * FROM t"
+        assert call.kwargs.get("hints") == {"odps.sql.mapper.split.size": "4096"}
+
     def test_3level_cost_applies_hints(self, isolated_config: Path) -> None:
         """3-level project cost must forward ``schema=`` so the client
         builds namespace/default-schema hints internally."""

--- a/tests/unit/mc_client/test_sql_preprocess.py
+++ b/tests/unit/mc_client/test_sql_preprocess.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2024-2026, Alibaba Cloud and its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for mc_client.sql_preprocess.split_set_hints."""
+
+from __future__ import annotations
+
+from maxcompute_semantic.mc_client.sql_preprocess import split_set_hints
+
+
+class TestSplitSetHints:
+    def test_extracts_set_and_preserves_select_verbatim(self) -> None:
+        sql = "SET odps.sql.mapper.split.size = 4096; SELECT a, b FROM t WHERE ds='20240101'"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT a, b FROM t WHERE ds='20240101'"
+        assert hints == {"odps.sql.mapper.split.size": "4096"}
+
+    def test_standalone_set_yields_empty_sql(self) -> None:
+        stripped, hints = split_set_hints("SET odps.sql.mapper.split.size=4096")
+        assert stripped == ""
+        assert hints == {"odps.sql.mapper.split.size": "4096"}
+
+    def test_multiple_sets_all_extracted(self) -> None:
+        sql = "SET odps.sql.allow.fullscan = true; SET odps.sql.reducer.memory = 4096; SELECT x FROM t"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT x FROM t"
+        assert hints == {"odps.sql.allow.fullscan": "TRUE", "odps.sql.reducer.memory": "4096"}
+
+    def test_semicolon_inside_string_literal_is_not_a_separator(self) -> None:
+        sql = "SET a=1; SELECT x FROM t WHERE s='a;b;c'"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT x FROM t WHERE s='a;b;c'"
+        assert hints == {"a": "1"}
+
+    def test_set_label_is_not_extracted_stays_verbatim(self) -> None:
+        sql = "SET LABEL tbl TO user; SELECT 1"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SET LABEL tbl TO user; SELECT 1"
+        assert hints == {}
+
+    def test_no_set_returns_unchanged(self) -> None:
+        stripped, hints = split_set_hints("SELECT 1 FROM dual")
+        assert stripped == "SELECT 1 FROM dual"
+        assert hints == {}
+
+    def test_non_select_preserved_verbatim_no_function_rewrite(self) -> None:
+        # TO_CHAR must NOT be rewritten to CAST — regeneration is lossy.
+        sql = "set odps.sql.type.system.odps2 = true; SELECT TO_CHAR(d, 'yyyyMMdd') FROM t"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT TO_CHAR(d, 'yyyyMMdd') FROM t"
+        assert hints == {"odps.sql.type.system.odps2": "TRUE"}
+
+    def test_trailing_semicolon_handled(self) -> None:
+        stripped, hints = split_set_hints("SET a=1; SELECT 1;")
+        assert stripped == "SELECT 1"
+        assert hints == {"a": "1"}
+
+    def test_duplicate_set_keys_last_wins(self) -> None:
+        sql = "SET a=1; SET a=2; SELECT 1"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == "SELECT 1"
+        assert hints == {"a": "2"}
+
+    def test_multi_statement_no_set_preserved_verbatim(self) -> None:
+        # No SETs extracted -> original SQL returned untouched (newlines
+        # between statements preserved, not reformatted to "; ").
+        sql = "SELECT 1;\nSELECT 2"
+        stripped, hints = split_set_hints(sql)
+        assert stripped == sql
+        assert hints == {}


### PR DESCRIPTION
## What

Two independent changes on `dev`:

### 1. SET statement extraction (`SET key=val` → pyodps hints)
`mcs sql submit` / `execute` / `cost` / `explain` / `review` now extract `SET key=val` statements into the pyodps `hints` dict **before** the write guard, cost gate, and submission — so `SET k=v; SELECT ...` scripts run transparently instead of failing.

**Before:** any SQL containing a `SET` was classified as `write` (needs `--allow-write`), and even with `--allow-write` a `SET;SELECT` script hit `CostBlocked` because the cost gate calls `execute_sql_cost` on the raw SQL and pyodps's `execute_sql_cost` (unlike `run_sql`) does not strip `SET` to hints.

**After:**
- `SET k=v; SELECT ...` → classified as the remaining statement (`read`, no `--allow-write`), runs normally.
- `SET k=v; INSERT ...` → still `write` (the INSERT), `--allow-write` required.
- `SET LABEL ...` / `SETPROJECT` (non-`key=val`) → **not extracted**, still gated as `write`/unparseable (guardrail preserved — these are real session/security ops).
- Standalone `SET k=v` (no query) → rejected with a clear "no query" message.

`classify_sql` is **intentionally unchanged** — extraction happens in the verbs before classification, so non-extractable SETs still reach the classifier and stay gated.

### 2. Drop OSS update channel (`11a1900`)
Removes the OSS install/update channel from `update_check.py` / `update.py` / `doctor.py` (+ tests). Unrelated to the SET feature; rebased underneath it.

### 3. CI improvements (`b3db34e`)
Riding along in this PR (motivated by this PR's CI runs):

- **mypy moved from `ci.yml` to `lint.yml`.** Previously `mypy src/` ran in the `test` matrix 3× (once per Python version) — mypy results are version-independent, so that was redundant. Now:
  - `lint.yml` has a new **`mypy-blocking`** job (`uv run mypy src/`) — blocking enforcement preserved, just relocated and de-duplicated to one run.
  - `lint.yml`'s `lint-diff` job now **runs mypy on HEAD + base and includes it in the PR-comment diff report** (codecov-style: new/resolved mypy issues shown alongside ruff/ty). The `Lint (ruff + ty)` workflow is renamed `Lint (ruff + ty + mypy)`.
  - `.lint-reports/` is uploaded as an artifact (audit trail).
  - `scripts/lint_diff.py` parses mypy plain-text (`--show-error-codes --no-pretty`) into the existing `{tool,rule,path,line,message}` shape.
- **pytest parallelised with xdist** in `ci.yml`: `-n auto --dist loadscope --maxfail=1` (replaces `-x`; `--dist loadscope` keeps each test module on one worker for module-scoped state / file locks). `pytest-xdist` was already a dev dep but unused.

Verified locally: YAML valid; `mypy src/` clean (128 files); mypy parser round-trips sample errors; full suite with xdist = 3368 passed, 0 new failures.

## How (SET extraction)
- New pure helper `maxcompute_semantic.mc_client.sql_preprocess.split_set_hints(sql) -> (stripped_sql, hints)`:
  - Uses the MaxCompute sqlglot **tokenizer** to split the SQL into verbatim statement segments at top-level semicolons (string- and comment-aware — `;` inside a literal / `--` comment is not a separator).
  - Parses each segment with `parse_mc`; segments that parse to an assignment `Set` (every `SetItem` is an `EQ`, not `UNSET`/tag/flag) become hints and are dropped; everything else (SELECT/DDL, and `SET LABEL` which parses as `Command`) is kept **verbatim** and rejoined.
  - Non-SET SQL is never AST-regenerated (the MaxCompute generator rewrites functions lossily — e.g. `TO_CHAR(d, fmt)` → `CAST(d AS STRING)` losing the format string).
  - Total: on tokenize failure (`TokenError`) returns the original SQL unchanged → the write guard emits its friendly parse-error remediation.
- Each verb calls `_split_or_emit(sql)` first, then passes `stripped_sql` to the guard/routing/client and `hints=set_hints or None` to the client methods (which already accept and thread `hints=` end-to-end). No client-layer changes.

## Verification
- 169 feature tests pass; full suite 3368 passed / 25 skipped.
- New tests: `split_set_hints` unit matrix (extraction, verbatim preservation, string-internal `;`, `SET LABEL` stays, multi-SET, duplicate-key last-wins, `TokenError` fallback) + verb integration (execute/submit/cost/review).
- Live end-to-end against a real MaxCompute profile:
  - `mcs sql cost  "SET odps.sql.mapper.split.size = 4096; SELECT 1"` → verdict `ok` (was `CostBlocked`).
  - `mcs sql execute --yes "SET ...; SELECT 1"` → `{"_c0": 1}` (runs, no `--allow-write`).
  - standalone `SET ...` → `WriteOpRejected` ("no query"); `classify_sql("SET ...")` still `"write"` (belt intact).
- One pre-existing, unrelated failure: `tests/unit/versioning/test_hook.py::test_concurrent_two_processes_via_subprocess` (OS-dependent file-lock contention) — confirmed failing at the base commit too, not a regression.

## Design / plan docs
- `docs/superpowers/specs/2026-06-23-set-statement-extraction-design.md`
- `docs/superpowers/plans/2026-06-23-set-statement-extraction.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)